### PR TITLE
feat: org invite email pipeline updates

### DIFF
--- a/src/app/LayoutContent.tsx
+++ b/src/app/LayoutContent.tsx
@@ -17,11 +17,13 @@ const noSidebarRoutes = [
   '/onboarding'
 ]
 
+function isInviteRoute(pathname: string): boolean {
+  return pathname.startsWith('/invite/')
+}
+
 function shouldShowSidebar(pathname: string): boolean {
-  // Hide sidebar for playground pages
-  if (pathname.includes('/playground')) {
-    return false
-  }
+  if (pathname.includes('/playground')) return false
+  if (isInviteRoute(pathname)) return false
   return !noSidebarRoutes.includes(pathname)
 }
 

--- a/src/app/api/projects/[id]/me/route.ts
+++ b/src/app/api/projects/[id]/me/route.ts
@@ -22,6 +22,11 @@ export async function GET(
     const { id: projectId } = await params
     const userEmail = user?.emailAddresses?.[0]?.emailAddress
 
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    if (!uuidRegex.test(projectId)) {
+      return NextResponse.json({ error: 'Invalid project ID' }, { status: 400 })
+    }
+
     const { data: mapping, error } = await supabase
       .from('pype_voice_email_project_mapping')
       .select('role, permissions, is_active')

--- a/src/app/api/projects/[id]/members/[memberId]/route.ts
+++ b/src/app/api/projects/[id]/members/[memberId]/route.ts
@@ -198,9 +198,12 @@ export async function DELETE(
       return NextResponse.json({ error: 'You cannot remove yourself' }, { status: 400 })
     }
 
-    // Handle permanent vs soft delete
-    if (permanent) {
-      // Hard delete - permanently remove from database
+    // Pending invites (no clerk_id) are always hard deleted
+    // so the invite token is permanently invalidated and the old link stops working.
+    // Active members (with clerk_id) are soft deleted so they can be re-added later.
+    const isPendingInvite = !memberToDelete.clerk_id
+
+    if (isPendingInvite || permanent) {
       const { error: deleteError } = await supabase
         .from('pype_voice_email_project_mapping')
         .delete()
@@ -208,16 +211,16 @@ export async function DELETE(
         .eq('project_id', projectId)
 
       if (deleteError) {
-        console.error('Error permanently deleting member:', deleteError)
-        return NextResponse.json({ error: 'Failed to permanently remove member' }, { status: 500 })
+        console.error('Error deleting member:', deleteError)
+        return NextResponse.json({ error: 'Failed to remove member' }, { status: 500 })
       }
 
       return NextResponse.json({ 
-        message: 'Member permanently removed',
-        type: 'permanent_delete' 
+        message: isPendingInvite ? 'Invite cancelled' : 'Member permanently removed',
+        type: isPendingInvite ? 'invite_cancelled' : 'permanent_delete',
       }, { status: 200 })
     } else {
-      // Soft delete - set is_active to false
+      // Soft delete active members — preserves history and allows re-adding
       const { error: deleteError } = await supabase
         .from('pype_voice_email_project_mapping')
         .update({ is_active: false })

--- a/src/app/api/projects/[id]/members/route.ts
+++ b/src/app/api/projects/[id]/members/route.ts
@@ -1,8 +1,10 @@
 // src/app/api/projects/[id]/members/route.ts
 import { NextRequest, NextResponse } from 'next/server'
 import { auth, currentUser } from '@clerk/nextjs/server'
+import { randomUUID } from 'crypto'
 import { DEFAULT_MEMBER_VISIBILITY, VIEWER_RESTRICTED_VISIBILITY } from '@/types/visibility'
 import { createServiceRoleClient } from '@/lib/supabase-server'
+import { sendInviteEmail } from '@/lib/sendInviteEmail'
 
 const supabase = createServiceRoleClient()
 
@@ -49,8 +51,11 @@ export async function POST(
       return NextResponse.json({ error: 'Email is required' }, { status: 400 })
     }
 
+    // Normalize to lowercase to prevent duplicate entries from casing differences
+    const normalizedEmail = email.trim().toLowerCase()
+
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-    if (!emailRegex.test(email.trim())) {
+    if (!emailRegex.test(normalizedEmail)) {
       return NextResponse.json({ error: 'Invalid email format' }, { status: 400 })
     }
 
@@ -74,11 +79,21 @@ export async function POST(
       )
     }
 
-    // ✅ NEW: Check if already added by email (INCLUDING INACTIVE ONES)
+    // Fetch project name for invite email
+    const { data: project } = await supabase
+      .from('pype_voice_projects')
+      .select('name')
+      .eq('id', projectId)
+      .maybeSingle()
+
+    const orgName = project?.name ?? 'your organization'
+    const appUrl = (process.env.NEXT_PUBLIC_APP_URL ?? 'https://www.whispey.xyz').replace(/\/$/, '')
+
+    // Check if already added by email (INCLUDING INACTIVE ONES)
     const { data: existingMapping, error: existingMappingError } = await supabase
       .from('pype_voice_email_project_mapping')
-      .select('id, is_active, clerk_id')
-      .eq('email', email.trim())
+      .select('id, is_active, clerk_id, invite_token')
+      .eq('email', normalizedEmail)
       .eq('project_id', projectId)
       .maybeSingle()
 
@@ -87,14 +102,15 @@ export async function POST(
       return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
     }
 
-    // ✅ NEW: If mapping exists and is active, return error
+    // If mapping exists and is active, return error
     if (existingMapping && (existingMapping.is_active === true || existingMapping.is_active === null)) {
       return NextResponse.json({ error: 'Email already added to project' }, { status: 400 })
     }
 
-    // ✅ NEW: If mapping exists but is inactive, reactivate it
+    // If mapping exists but is inactive, reactivate it
     if (existingMapping && existingMapping.is_active === false) {
       const permissions = getPermissionsByRole(normalizedRole)
+      const isPending = !existingMapping.clerk_id
 
       const { data: reactivatedMapping, error: reactivateError } = await supabase
         .from('pype_voice_email_project_mapping')
@@ -102,7 +118,12 @@ export async function POST(
           is_active: true,
           role: normalizedRole,
           permissions,
-          added_by_clerk_id: userId
+          added_by_clerk_id: userId,
+          // Generate a new token for pending users to invalidate the old invite link
+          ...(isPending && {
+            invite_token: randomUUID(),
+            invite_sent_at: new Date().toISOString(),
+          }),
         })
         .eq('id', existingMapping.id)
         .select()
@@ -113,10 +134,24 @@ export async function POST(
         return NextResponse.json({ error: 'Failed to add member' }, { status: 500 })
       }
 
+      const isExistingUser = !isPending
+      const inviteLink = isExistingUser
+        ? `${appUrl}/${projectId}/agents`
+        : `${appUrl}/invite/${reactivatedMapping.invite_token}`
+
+      let inviteSent = false
+      try {
+        await sendInviteEmail({ email: normalizedEmail, orgName, inviteLink, isExistingUser })
+        inviteSent = true
+      } catch (err) {
+        console.warn('[invite] User re-added to project, but email could not be sent:', err instanceof Error ? err.message : String(err))
+      }
+
       return NextResponse.json({ 
         message: 'User re-added to project', 
         member: reactivatedMapping,
-        type: 'reactivated'
+        type: 'reactivated',
+        inviteSent,
       }, { status: 201 })
     }
 
@@ -125,7 +160,7 @@ export async function POST(
     const { data: existingUser, error: existingUserError } = await supabase
       .from('pype_voice_users')
       .select('clerk_id')
-      .eq('email', email.trim())
+      .eq('email', normalizedEmail)
       .maybeSingle()
 
     if (existingUserError) {
@@ -160,7 +195,7 @@ export async function POST(
         .from('pype_voice_email_project_mapping')
         .insert({
           clerk_id: existingUser.clerk_id,
-          email: email.trim(),
+          email: normalizedEmail,
           project_id: projectId,
           role: normalizedRole,
           permissions,
@@ -175,22 +210,38 @@ export async function POST(
         return NextResponse.json({ error: 'Failed to add member' }, { status: 500 })
       }
 
+      let inviteSent = false
+      try {
+        await sendInviteEmail({
+          email: normalizedEmail,
+          orgName,
+          inviteLink: `${appUrl}/${projectId}/agents`,
+          isExistingUser: true,
+        })
+        inviteSent = true
+      } catch (err) {
+        console.warn('[invite] User added to project, but email could not be sent:', err instanceof Error ? err.message : String(err))
+      }
+
       return NextResponse.json({ 
         message: 'User added to project', 
         member: newMapping,
-        type: 'direct_add'
+        type: 'direct_add',
+        inviteSent,
       }, { status: 201 })
     } else {
       // Create pending email-based invite
       const { data: mapping, error } = await supabase
         .from('pype_voice_email_project_mapping')
         .insert({
-          email: email.trim(),
+          email: normalizedEmail,
           project_id: projectId,
           role: normalizedRole,
           permissions,
           added_by_clerk_id: userId,
           is_active: true,
+          invite_sent_at: new Date().toISOString(),
+          // invite_token auto-generated by DB DEFAULT gen_random_uuid()
         })
         .select()
         .single()
@@ -200,11 +251,25 @@ export async function POST(
         return NextResponse.json({ error: 'Failed to add member' }, { status: 500 })
       }
 
+      let inviteSent = false
+      try {
+        await sendInviteEmail({
+          email: normalizedEmail,
+          orgName,
+          inviteLink: `${appUrl}/invite/${mapping.invite_token}`,
+          isExistingUser: false,
+        })
+        inviteSent = true
+      } catch (err) {
+        console.warn('[invite] User added to pending list, but email could not be sent:', err instanceof Error ? err.message : String(err))
+      }
+
       return NextResponse.json(
         {
-          message: 'Email added to project successfully. User will be added when they sign up.',
+          message: 'Invite sent. User will be added when they sign up.',
           member: mapping,
-          type: 'email_mapping'
+          type: 'email_mapping',
+          inviteSent,
         },
         { status: 201 }
       )
@@ -262,8 +327,9 @@ export async function GET(
     }
 
     // Separate members into groups
+    // Only show active pending mappings — soft-deleted ones (is_active=false) should not appear
     const membersWithClerkId = allProjectMappings?.filter((m: any) => m.clerk_id) || []
-    const pendingMappings = allProjectMappings?.filter((m: any) => !m.clerk_id) || []
+    const pendingMappings = allProjectMappings?.filter((m: any) => !m.clerk_id && m.is_active !== false) || []
 
     // Get user details for members with clerk_id
     let membersWithDetails: any[] = []

--- a/src/app/api/user/create/route.ts
+++ b/src/app/api/user/create/route.ts
@@ -5,6 +5,29 @@ import { createServiceRoleClient } from '@/lib/supabase-server'
 
 const supabase = createServiceRoleClient()
 
+// Links any pending invite mappings (clerk_id = null) for this email to the
+// current clerk userId. Safe to call multiple times — only updates null rows.
+// This runs here because the Clerk webhook may not fire in dev or may fail,
+// so /api/user/create is the reliable fallback that always runs after signup.
+async function linkPendingInvites(userId: string, email: string) {
+  try {
+    const { error } = await supabase
+      .from('pype_voice_email_project_mapping')
+      .update({ clerk_id: userId })
+      .eq('email', email)
+      .is('clerk_id', null)
+      .eq('is_active', true)
+
+    if (error) {
+      console.error('⚠️ Failed to link pending invites:', error)
+    } else {
+      console.log('🔗 Linked pending invites for', email)
+    }
+  } catch (err) {
+    console.error('⚠️ Error linking pending invites:', err)
+  }
+}
+
 export async function POST(request: NextRequest) {
   try {
     const { userId } = await auth()
@@ -30,6 +53,10 @@ export async function POST(request: NextRequest) {
       .maybeSingle()
 
     if (existingUser) {
+      // User already exists — still try to link pending invites in case
+      // the Clerk webhook fired but the linking step failed
+      await linkPendingInvites(userId, email)
+
       return NextResponse.json({ 
         message: 'User already exists',
         userId: existingUser.id,
@@ -66,6 +93,9 @@ export async function POST(request: NextRequest) {
     }
 
     console.log('✅ User created:', newUser.email)
+
+    // Link any pending invite mappings for this newly created user
+    await linkPendingInvites(userId, email)
 
     return NextResponse.json({ 
       message: 'User created successfully',

--- a/src/app/api/webhooks/clerk/route.ts
+++ b/src/app/api/webhooks/clerk/route.ts
@@ -77,12 +77,13 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   try {
     if (eventType === 'user.created') {
       const { email_addresses, first_name, last_name, image_url } = evt.data
+      const userEmail = email_addresses[0]?.email_address || ''
 
       console.log('✅ Creating new user in database')
 
       const { data, error } = await supabase.from('pype_voice_users').insert({
         clerk_id: id,
-        email: email_addresses[0]?.email_address || '',
+        email: userEmail,
         first_name: first_name,
         last_name: last_name,
         profile_image_url: image_url,
@@ -94,6 +95,25 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       }
 
       console.log('🎉 User created successfully:', data)
+
+      // Link any pending invite mappings for this email
+      // Non-fatal — user still has access via email-based lookup even if this fails
+      try {
+        const { error: linkError } = await supabase
+          .from('pype_voice_email_project_mapping')
+          .update({ clerk_id: id })
+          .eq('email', userEmail)
+          .is('clerk_id', null)
+          .eq('is_active', true)
+
+        if (linkError) {
+          console.error('⚠️ Failed to link pending invites for', userEmail, linkError)
+        } else {
+          console.log('🔗 Linked pending invites for', userEmail)
+        }
+      } catch (linkErr) {
+        console.error('⚠️ Error linking pending invites for', userEmail, linkErr)
+      }
     }
 
     if (eventType === 'user.updated') {

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -1,0 +1,55 @@
+import { redirect } from 'next/navigation'
+import { auth } from '@clerk/nextjs/server'
+import { createServiceRoleClient } from '@/lib/supabase-server'
+
+export default async function InvitePage({
+  params,
+}: {
+  params: Promise<{ token: string }>
+}) {
+  const { token } = await params
+
+  const { userId } = await auth()
+  const supabase = createServiceRoleClient()
+
+  const { data: mapping } = await supabase
+    .from('pype_voice_email_project_mapping')
+    .select('project_id')
+    .eq('invite_token', token)
+    .eq('is_active', true)
+    .maybeSingle()
+
+  // Invalid or expired token — show error page (works for unauthenticated users too)
+  if (!mapping) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 px-4">
+        <div className="max-w-md w-full text-center space-y-4">
+          <div className="text-5xl">🔗</div>
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
+            Invalid Invite Link
+          </h1>
+          <p className="text-gray-500 dark:text-gray-400">
+            This invite link is invalid or has expired. Please ask your admin to send a new invite.
+          </p>
+          <a
+            href="/sign-in"
+            className="inline-block mt-4 px-6 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
+          >
+            Go to Sign In
+          </a>
+        </div>
+      </div>
+    )
+  }
+
+  const projectPath = `/${mapping.project_id}/agents`
+
+  if (userId) {
+    redirect(projectPath)
+  }
+
+  // Build full absolute URL so Clerk can redirect correctly after sign-in/sign-up
+  const appUrl = (process.env.NEXT_PUBLIC_APP_URL ?? 'https://www.whispey.xyz').replace(/\/$/, '')
+  const fullRedirectUrl = `${appUrl}${projectPath}`
+  redirect(`/sign-in?redirect_url=${encodeURIComponent(fullRedirectUrl)}`)
+}

--- a/src/app/sign-in/page.tsx
+++ b/src/app/sign-in/page.tsx
@@ -1,7 +1,11 @@
 // src/app/sign-in/page.tsx
 import AuthPage from "@/components/AuthPage";
 
-export default function SignInPage() {
-    return <AuthPage/>
+export default async function SignInPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ redirect_url?: string }>
+}) {
+  const params = await searchParams
+  return <AuthPage redirectUrl={params.redirect_url} />
 }
-

--- a/src/components/AuthPage.tsx
+++ b/src/components/AuthPage.tsx
@@ -4,7 +4,11 @@ import { SignIn } from '@clerk/nextjs';
 import Image from 'next/image';
 import { Mic, Sparkles, Shield, Zap } from 'lucide-react';
 
-export default function AuthPage() {
+interface AuthPageProps {
+  redirectUrl?: string
+}
+
+export default function AuthPage({ redirectUrl }: AuthPageProps) {
   return (
     <div className="h-screen bg-white flex overflow-hidden">
       {/* Left Side - Branding & Value Proposition */}
@@ -117,7 +121,7 @@ export default function AuthPage() {
                   socialButtonsPlacement: "top"
                 }
               }}
-              redirectUrl="/projects"
+              redirectUrl={redirectUrl ?? '/projects'}
             />
           </div>
 

--- a/src/components/MemberManagmentDialog.tsx
+++ b/src/components/MemberManagmentDialog.tsx
@@ -1,6 +1,7 @@
 // components/MemberManagementDialog.tsx
 'use client'
 import React, { useState, useEffect } from 'react'
+import toast from 'react-hot-toast'
 import {
   Dialog,
   DialogContent,
@@ -66,7 +67,6 @@ const MemberManagementDialog: React.FC<MemberManagementDialogProps> = ({
   const [members, setMembers] = useState<Member[]>([])
   const [pendingMappings, setPendingMappings] = useState<PendingMapping[]>([])
   const [fetchingMembers, setFetchingMembers] = useState(false)
-  const [message, setMessage] = useState<{ type: 'success' | 'error', text: string } | null>(null)
 
   // Check if current user can manage members
   const canManageMembers = project?.user_role === 'owner' || project?.user_role === 'admin'
@@ -102,12 +102,11 @@ const MemberManagementDialog: React.FC<MemberManagementDialogProps> = ({
     e.preventDefault()
     
     if (!project || !email.trim()) {
-      setMessage({ type: 'error', text: 'Please enter an email address' })
+      toast.error('Please enter an email address')
       return
     }
 
     setLoading(true)
-    setMessage(null)
 
     try {
       const response = await fetch(`/api/projects/${project.id}/members`, {
@@ -129,12 +128,20 @@ const MemberManagementDialog: React.FC<MemberManagementDialogProps> = ({
         throw new Error(data.error || 'Member must be logged in.')
       }
 
-      setMessage({ 
-        type: 'success', 
-        text: data.type === 'direct_add' 
-          ? 'User added to project successfully!'
-          : 'Email added! User will be added when they sign up.'
-      })
+      if (data.inviteSent === false) {
+        toast.error(
+          data.type === 'direct_add'
+            ? 'User added to project, but the invite email could not be sent. Check your email configuration.'
+            : 'User added to pending list, but the invite email could not be sent. Check your email configuration.',
+          { duration: 5000 }
+        )
+      } else {
+        toast.success(
+          data.type === 'direct_add'
+            ? 'User added to project successfully! An invite email has been sent.'
+            : 'Invite sent! User will be added when they sign up.'
+        )
+      }
       
       setEmail('')
       setRole('viewer')
@@ -144,7 +151,7 @@ const MemberManagementDialog: React.FC<MemberManagementDialogProps> = ({
       
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : 'Member must be logged in.'
-      setMessage({ type: 'error', text: errorMessage })
+      toast.error(errorMessage, { duration: 5000 })
     } finally {
       setLoading(false)
     }
@@ -175,7 +182,6 @@ const MemberManagementDialog: React.FC<MemberManagementDialogProps> = ({
   const handleClose = () => {
     setEmail('')
     setRole('viewer')
-    setMessage(null)
     setMembers([])
     setPendingMappings([])
     onClose()
@@ -211,16 +217,6 @@ const MemberManagementDialog: React.FC<MemberManagementDialogProps> = ({
             <div className="space-y-4">
               <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Add New Member</h3>
               
-              {message && (
-                <div className={`p-3 rounded-lg ${
-                  message.type === 'success' 
-                    ? 'bg-green-50 dark:bg-green-900/20 text-green-800 dark:text-green-300 border border-green-200 dark:border-green-800' 
-                    : 'bg-red-50 dark:bg-red-900/20 text-red-800 dark:text-red-300 border border-red-200 dark:border-red-800'
-                }`}>
-                  {message.text}
-                </div>
-              )}
-
               <form onSubmit={handleAddMember} className="space-y-4">
                 <div>
                   <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">

--- a/src/components/projects/OrganizationSettings.tsx
+++ b/src/components/projects/OrganizationSettings.tsx
@@ -170,12 +170,14 @@ export default function OrganizationSettings({
   const allMembers = [...teamMembers, ...pendingMembers]
 
   const handleInviteMember = async () => {
-    if (!inviteEmail || !inviteEmail.includes('@')) {
+    const normalizedEmail = inviteEmail.trim().toLowerCase()
+
+    if (!normalizedEmail || !normalizedEmail.includes('@')) {
       toast.error('Please enter a valid email address')
       return
     }
 
-    if (teamMembers.some(m => m.email === inviteEmail)) {
+    if (teamMembers.some(m => m.email === normalizedEmail)) {
       toast.error('This user is already a member of the organization')
       return
     }
@@ -189,7 +191,7 @@ export default function OrganizationSettings({
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          email: inviteEmail.trim(),
+          email: normalizedEmail,
           role: inviteRole
         }),
       })
@@ -205,12 +207,22 @@ export default function OrganizationSettings({
       setInviteEmail('')
       setInviteRole('viewer')
 
-      if (data.type === 'direct_add') {
-        toast.success(`${inviteEmail} has been added to the organization!`)
-      } else if (data.type === 'reactivated') {
-        toast.success(`${inviteEmail} has been reactivated!`)
+      if (data.inviteSent === false) {
+        if (data.type === 'direct_add') {
+          toast.error(`${normalizedEmail} added to the organization, but the invite email could not be sent. Check your email configuration.`, { duration: 5000 })
+        } else if (data.type === 'reactivated') {
+          toast.error(`${normalizedEmail} re-added, but the invite email could not be sent. Check your email configuration.`, { duration: 5000 })
+        } else {
+          toast.error(`${normalizedEmail} added to pending list, but the invite email could not be sent. Check your email configuration.`, { duration: 5000 })
+        }
       } else {
-        toast.success(`Invitation sent to ${inviteEmail}. They'll be added when they sign up.`)
+        if (data.type === 'direct_add') {
+          toast.success(`${normalizedEmail} has been added to the organization!`)
+        } else if (data.type === 'reactivated') {
+          toast.success(`${normalizedEmail} has been reactivated!`)
+        } else {
+          toast.success(`Invitation sent to ${normalizedEmail}. They'll be added when they sign up.`)
+        }
       }
     } catch (error) {
       console.error('Error inviting member:', error)

--- a/src/components/shared/SidebarWrapper.tsx
+++ b/src/components/shared/SidebarWrapper.tsx
@@ -22,7 +22,7 @@ interface SidebarWrapperProps {
 const ENHANCED_PROJECT_ID = '371c4bbb-76db-4c61-9926-bd75726a1cda'
 
 // Reserved paths that are NOT project IDs
-const RESERVED_PATHS = ['sign', 'docs', 'projects', 'onboarding', 'privacy-policy', 'terms-of-service']
+const RESERVED_PATHS = ['sign', 'docs', 'projects', 'onboarding', 'privacy-policy', 'terms-of-service', 'invite']
 
 interface RoutePattern {
   pattern: string

--- a/src/lib/sendInviteEmail.ts
+++ b/src/lib/sendInviteEmail.ts
@@ -1,0 +1,50 @@
+interface InviteEmailParams {
+  email: string
+  orgName: string
+  inviteLink: string
+  isExistingUser: boolean
+}
+
+export async function sendInviteEmail({
+  email,
+  orgName,
+  inviteLink,
+  isExistingUser,
+}: InviteEmailParams): Promise<void> {
+  const transactionalId = isExistingUser
+    ? process.env.LOOPS_EXISTING_USER_INVITE_TEMPLATE_ID
+    : process.env.LOOPS_NEW_USER_INVITE_TEMPLATE_ID
+
+  if (!transactionalId) {
+    throw new Error(
+      `Loops template ID not configured: ${
+        isExistingUser
+          ? 'LOOPS_EXISTING_USER_INVITE_TEMPLATE_ID'
+          : 'LOOPS_NEW_USER_INVITE_TEMPLATE_ID'
+      }`
+    )
+  }
+
+  if (!process.env.LOOPS_API_KEY) {
+    throw new Error('LOOPS_API_KEY not configured')
+  }
+
+  const response = await fetch('https://app.loops.so/api/v1/transactional', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${process.env.LOOPS_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      transactionalId,
+      email,
+      dataVariables: { orgName, inviteLink },
+      addToAudience: false,
+    }),
+  })
+
+  if (!response.ok) {
+    const errorText = await response.text()
+    throw new Error(`Loops API error ${response.status}: ${errorText}`)
+  }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,10 +8,10 @@ const isPublicRoute = createRouteMatcher([
   "/terms-of-service(.*)",
   "/privacy-policy(.*)",
   '/docs(.*)',
-  '/playground(.*)', // Explicit playground route pattern
+  '/playground(.*)',
+  '/invite(.*)',
   // '/api/webhooks(.*)', // if you have public API routes
   '/api(.*)'
-  // Add other public routes here
 ]);
 
 export default clerkMiddleware(async (auth, request) => {


### PR DESCRIPTION
## feat: Organization Invite System

### Summary
Adds a complete invite flow for adding users to organizations. Handles two cases — existing Whispey users get a "Welcome back" email with a direct org link, new users get an "You're invited" email with a signup link that auto-links their account on registration.

---

### New Files
- `src/lib/sendInviteEmail.ts` — Loops.so transactional email utility
- `src/app/invite/[token]/page.tsx` — Public page that validates invite tokens and redirects

### Modified Files
- `src/middleware.ts` — `/invite(.*)` added as public route
- `src/app/api/projects/[id]/members/route.ts` — Core invite logic, email normalization, token generation, `inviteSent` flag
- `src/app/api/projects/[id]/members/[memberId]/route.ts` — Hard delete pending invites on removal
- `src/app/api/webhooks/clerk/route.ts` — Links pending invites on `user.created`
- `src/app/api/user/create/route.ts` — Fallback invite linking when webhook is delayed
- `src/app/sign-in/page.tsx` — Reads `redirect_url` from query params
- `src/components/AuthPage.tsx` — Forwards `redirectUrl` to Clerk `<SignIn>`
- `src/components/projects/OrganizationSettings.tsx` — Toast feedback, email normalization in UI
- `src/components/MemberManagmentDialog.tsx` — Replaced inline messages with `react-hot-toast`

---

### Key Behaviors

- **Existing user** → added to DB with `clerk_id`, receives "Welcome back" email linking to `/{projectId}/agents`
- **New user** → pending row created with `invite_token`, receives "You're invited" email linking to `/invite/{token}`, `clerk_id` auto-linked on signup
- **Email failure** → member still saved to DB, admin sees red toast: *"email could not be sent — check configuration"*
- **Admin resends** → new `invite_token` generated, old link invalidated
- **Invalid/removed token** → inline error UI on invite page, no crash
- **Email casing** → normalized to lowercase before all DB ops and UI display

---

### Database Migration

Run once in Supabase before deploying:

ALTER TABLE pype_voice_email_project_mapping
  ADD COLUMN IF NOT EXISTS invite_token UUID DEFAULT gen_random_uuid(),
  ADD COLUMN IF NOT EXISTS invite_sent_at TIMESTAMPTZ;

CREATE UNIQUE INDEX IF NOT EXISTS idx_invite_token
  ON pype_voice_email_project_mapping (invite_token);
