### PR TITLE
Allow viewer role to build charts in overview

### DIFF
--- a/src/components/Overview.tsx
+++ b/src/components/Overview.tsx
@@ -1176,8 +1176,7 @@ const Overview: React.FC<OverviewProps> = ({
 
         {/* Chart Analytics Section — extra builder; gated by overview.charts + org.metrics */}
         {!isMobile &&
-          visibility?.agent?.overview.charts === true &&
-          canShowOrgSection(visibility, 'metrics') && (
+               visibility?.agent?.overview.charts === true && (
           <ChartProvider>
             <div className="space-y-6">
               <EnhancedChartBuilder 


### PR DESCRIPTION
Enable viewer role to access the chart builder and custom chart creation in the Overview section.
Removed `canShowOrgSection(visibility, 'metrics')` gate from `Overview.tsx`; no backend or permission changes.