### PR TITLE
make setup-supabase.sql idempotent and fix SQL syntax errors

### DIFF
--- a/setup-supabase.sql
+++ b/setup-supabase.sql
@@ -557,6 +557,8 @@ SELECT
   COUNT(*) AS calls,
   SUM(duration_seconds) AS total_seconds,
   ROUND(SUM(duration_seconds)::numeric / 60, 0) AS total_minutes,
+  COALESCE(SUM(billing_duration_seconds), 0) AS total_billing_seconds,
+  ROUND(COALESCE(SUM(billing_duration_seconds), 0)::numeric / 60, 0) AS total_billing_minutes,
   AVG(avg_latency) AS avg_latency,
   COUNT(DISTINCT call_id) AS unique_customers,
   COUNT(*) FILTER (WHERE call_ended_reason = 'completed') AS successful_calls,

--- a/setup-supabase.sql
+++ b/setup-supabase.sql
@@ -1266,6 +1266,9 @@ CREATE TABLE IF NOT EXISTS public.pype_voice_phone_numbers (
     trunk_direction varchar NOT NULL DEFAULT 'outbound'::character varying
 );
 
+-- Drop first so we can change the RETURNS TABLE definition (CREATE OR REPLACE cannot change return type)
+DROP FUNCTION IF EXISTS get_call_logs_with_distinct(uuid, jsonb, jsonb, text, text, boolean, integer, integer, text, text, text, text, text, text, text) CASCADE;
+
 -- Function to get call logs with distinct and filtering support
 CREATE OR REPLACE FUNCTION get_call_logs_with_distinct(
   p_agent_id uuid,
@@ -1312,7 +1315,8 @@ RETURNS TABLE(
   telemetry_data jsonb,
   billing_duration_seconds float8,
   metrics jsonb,
-  updated_at timestamp
+  updated_at timestamp,
+  wcall_event varchar
 ) AS $$
 DECLARE
   query_text TEXT;
@@ -1326,7 +1330,10 @@ DECLARE
   order_clause TEXT := '';
   user_role TEXT;
   user_visibility JSONB;
-  select_columns TEXT;
+  -- Fixed column list matching RETURNS TABLE order exactly. p_select is accepted
+  -- for API compatibility but ignored internally — RETURN QUERY EXECUTE matches
+  -- columns positionally so the shape must always match RETURNS TABLE.
+  select_columns CONSTANT TEXT := 'id,call_id,agent_id,customer_number,call_ended_reason,transcript_type,transcript_json,metadata,dynamic_variables,environment,created_at,call_started_at,call_ended_at,duration_seconds,recording_url,avg_latency,transcription_metrics,total_stt_cost,total_tts_cost,total_llm_cost,p50_latency,complete_configuration,telemetry_spans,telemetry_analytics,telemetry_data,billing_duration_seconds,metrics,updated_at,wcall_event';
 BEGIN
   -- Get user role and visibility if identifying info provided
   IF p_user_clerk_id IS NOT NULL OR p_user_email IS NOT NULL THEN
@@ -1339,7 +1346,7 @@ BEGIN
       (p_user_clerk_id IS NOT NULL AND clerk_id = p_user_clerk_id)
       OR (p_user_email IS NOT NULL AND email = p_user_email)
     )
-    AND project_id = (SELECT project_id FROM pype_voice_agents WHERE id = p_agent_id)
+    AND project_id = (SELECT project_id FROM pype_voice_agents WHERE pype_voice_agents.id = p_agent_id)
     AND (is_active IS NULL OR is_active = true)
     LIMIT 1;
 
@@ -1347,11 +1354,6 @@ BEGIN
     IF user_role IS NULL THEN
       RETURN;
     END IF;
-
-    -- Viewer: still return full columns so RETURNS TABLE shape is consistent; frontend hides cost/latency for viewers
-    select_columns := p_select;
-  ELSE
-    select_columns := p_select;
   END IF;
 
   -- Build base query

--- a/setup-supabase.sql
+++ b/setup-supabase.sql
@@ -86,11 +86,7 @@ CREATE TABLE public.pype_voice_call_logs (
     created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
     call_started_at timestamp without time zone,
     call_ended_at timestamp without time zone,
-    duration_seconds int4 DEFAULT 
-CASE
-    WHEN ((call_ended_at IS NOT NULL) AND (call_started_at IS NOT NULL)) THEN (EXTRACT(epoch FROM (call_ended_at - call_started_at)))::integer
-    ELSE NULL::integer
-END,
+    duration_seconds int4,
     recording_url text,
     avg_latency float8,
     transcription_metrics jsonb,
@@ -154,7 +150,7 @@ CREATE TABLE public.pype_voice_email_project_mapping (
     added_by_clerk_id text,
     created_at timestamp with time zone DEFAULT now(),
     clerk_id text,
-    is_active boolean,
+    is_active boolean
 );
 
 CREATE TABLE public.pype_voice_api_keys (
@@ -257,7 +253,7 @@ CREATE TABLE public.pype_voice_metric_groups (
     updated_at timestamp with time zone DEFAULT now()
 );
 
-CREATE TABLE public.pype_voice_agent_dropoff_settings (
+CREATE TABLE IF NOT EXISTS public.pype_voice_agent_dropoff_settings (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     agent_id uuid NOT NULL,
     agent_name varchar NOT NULL,
@@ -1227,7 +1223,7 @@ COMMENT ON COLUMN public.pype_voice_dropoff_calls.stop_reason IS 'Reason why ret
 -- Additional Tables
 -- ========================================
 
-CREATE TABLE public.pype_voice_metrics_templates (
+CREATE TABLE IF NOT EXISTS public.pype_voice_metrics_templates (
     metric_id varchar PRIMARY KEY,
     name varchar NOT NULL,
     description text,
@@ -1244,7 +1240,7 @@ CREATE TABLE public.pype_voice_metrics_templates (
     updated_at timestamp without time zone DEFAULT now()
 );
 
-CREATE TABLE public.pype_voice_phone_numbers (
+CREATE TABLE IF NOT EXISTS public.pype_voice_phone_numbers (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     phone_number text NOT NULL,
     country_code text,
@@ -1423,7 +1419,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;
 
-CREATE TABLE public.pype_voice_webhook_configs (
+CREATE TABLE IF NOT EXISTS public.pype_voice_webhook_configs (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     project_id uuid NOT NULL,
     agent_id uuid,

--- a/src/app/api/agents/[id]/call-logs/query/route.ts
+++ b/src/app/api/agents/[id]/call-logs/query/route.ts
@@ -4,6 +4,7 @@ import { getProjectRoleForApi } from '@/lib/getProjectRoleForApi'
 import { redactTagsFromCallLogsForViewer } from '@/lib/redactCallLogsTagsForViewer'
 import type { CallLog } from '@/types/logs'
 import { createServiceRoleClient } from '@/lib/supabase-server'
+import { queryCallLogs } from '@/lib/queryCallLogs'
 
 const supabase = createServiceRoleClient()
 
@@ -13,7 +14,6 @@ export async function POST(
 ) {
   const { id: agentIdFromUrl } = await params
   const { userId } = await auth()
-  const user = await currentUser()
   if (!userId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
@@ -45,55 +45,24 @@ export async function POST(
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
 
-  const userEmail = user?.emailAddresses?.[0]?.emailAddress ?? null
-
-  const rpcParamsWithUser = {
+  const { data, error } = await queryCallLogs(supabase, {
     p_agent_id,
-    p_pre_distinct_filters: body.p_pre_distinct_filters ?? [],
-    p_post_distinct_filters: body.p_post_distinct_filters ?? [],
-    p_select: body.p_select ?? '*',
-    p_order_by_column: body.p_order_by_column ?? 'created_at',
-    p_order_ascending: body.p_order_ascending ?? false,
-    p_limit: body.p_limit ?? 50,
-    p_offset: body.p_offset ?? 0,
-    p_distinct_column: body.p_distinct_column ?? null,
-    p_distinct_json_field: body.p_distinct_json_field ?? null,
-    p_distinct_order: body.p_distinct_order ?? 'asc',
-    p_date_from: body.p_date_from ?? null,
-    p_date_to: body.p_date_to ?? null,
-    p_user_clerk_id: userId,
-    p_user_email: userEmail,
-  }
-
-  let { data, error } = await supabase.rpc('get_call_logs_with_distinct', rpcParamsWithUser)
-
-  if (error?.code === 'PGRST202') {
-    const params13 = {
-      p_agent_id: rpcParamsWithUser.p_agent_id,
-      p_pre_distinct_filters: rpcParamsWithUser.p_pre_distinct_filters,
-      p_post_distinct_filters: rpcParamsWithUser.p_post_distinct_filters,
-      p_select: rpcParamsWithUser.p_select,
-      p_order_by_column: rpcParamsWithUser.p_order_by_column,
-      p_order_ascending: rpcParamsWithUser.p_order_ascending,
-      p_limit: rpcParamsWithUser.p_limit,
-      p_offset: rpcParamsWithUser.p_offset,
-      p_distinct_column: rpcParamsWithUser.p_distinct_column,
-      p_distinct_json_field: rpcParamsWithUser.p_distinct_json_field,
-      p_distinct_order: rpcParamsWithUser.p_distinct_order,
-      p_date_from: rpcParamsWithUser.p_date_from,
-      p_date_to: rpcParamsWithUser.p_date_to,
-    }
-    const fallback = await supabase.rpc('get_call_logs_with_distinct', params13)
-    if (fallback.error) {
-      console.error('rpc fallback error:', fallback.error)
-      return NextResponse.json({ error: fallback.error.message }, { status: 500 })
-    }
-    data = fallback.data
-    error = null
-  }
+    p_pre_distinct_filters: (body.p_pre_distinct_filters as any[]) ?? [],
+    p_post_distinct_filters: (body.p_post_distinct_filters as any[]) ?? [],
+    p_select: (body.p_select as string) ?? '*',
+    p_order_by_column: (body.p_order_by_column as string) ?? 'created_at',
+    p_order_ascending: (body.p_order_ascending as boolean) ?? false,
+    p_limit: (body.p_limit as number) ?? 50,
+    p_offset: (body.p_offset as number) ?? 0,
+    p_distinct_column: (body.p_distinct_column as string) ?? null,
+    p_distinct_json_field: (body.p_distinct_json_field as string) ?? null,
+    p_distinct_order: (body.p_distinct_order as string) ?? 'asc',
+    p_date_from: (body.p_date_from as string) ?? null,
+    p_date_to: (body.p_date_to as string) ?? null,
+  })
 
   if (error) {
-    console.error('get_call_logs_with_distinct:', error)
+    console.error('queryCallLogs:', error)
     return NextResponse.json({ error: error.message }, { status: 500 })
   }
 

--- a/src/app/api/projects/[id]/call-logs/query/route.ts
+++ b/src/app/api/projects/[id]/call-logs/query/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { auth, currentUser } from '@clerk/nextjs/server'
+import { auth } from '@clerk/nextjs/server'
 import { getProjectRoleForApi } from '@/lib/getProjectRoleForApi'
 import { redactTagsFromCallLogsForViewer } from '@/lib/redactCallLogsTagsForViewer'
 import type { CallLog } from '@/types/logs'
 import { createServiceRoleClient } from '@/lib/supabase-server'
+import { queryCallLogs } from '@/lib/queryCallLogs'
 
 const supabase = createServiceRoleClient()
 
@@ -13,7 +14,6 @@ export async function POST(
 ) {
   const { id: projectId } = await params
   const { userId } = await auth()
-  const user = await currentUser()
   if (!userId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
@@ -45,55 +45,24 @@ export async function POST(
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
 
-  const userEmail = user?.emailAddresses?.[0]?.emailAddress ?? null
-
-  const rpcParamsWithUser = {
+  const { data, error } = await queryCallLogs(supabase, {
     p_agent_id,
-    p_pre_distinct_filters: body.p_pre_distinct_filters ?? [],
-    p_post_distinct_filters: body.p_post_distinct_filters ?? [],
-    p_select: body.p_select ?? '*',
-    p_order_by_column: body.p_order_by_column ?? 'created_at',
-    p_order_ascending: body.p_order_ascending ?? false,
-    p_limit: body.p_limit ?? 50,
-    p_offset: body.p_offset ?? 0,
-    p_distinct_column: body.p_distinct_column ?? null,
-    p_distinct_json_field: body.p_distinct_json_field ?? null,
-    p_distinct_order: body.p_distinct_order ?? 'asc',
-    p_date_from: body.p_date_from ?? null,
-    p_date_to: body.p_date_to ?? null,
-    p_user_clerk_id: userId,
-    p_user_email: userEmail,
-  }
-
-  let { data, error } = await supabase.rpc('get_call_logs_with_distinct', rpcParamsWithUser)
-
-  if (error?.code === 'PGRST202') {
-    const params13 = {
-      p_agent_id: rpcParamsWithUser.p_agent_id,
-      p_pre_distinct_filters: rpcParamsWithUser.p_pre_distinct_filters,
-      p_post_distinct_filters: rpcParamsWithUser.p_post_distinct_filters,
-      p_select: rpcParamsWithUser.p_select,
-      p_order_by_column: rpcParamsWithUser.p_order_by_column,
-      p_order_ascending: rpcParamsWithUser.p_order_ascending,
-      p_limit: rpcParamsWithUser.p_limit,
-      p_offset: rpcParamsWithUser.p_offset,
-      p_distinct_column: rpcParamsWithUser.p_distinct_column,
-      p_distinct_json_field: rpcParamsWithUser.p_distinct_json_field,
-      p_distinct_order: rpcParamsWithUser.p_distinct_order,
-      p_date_from: rpcParamsWithUser.p_date_from,
-      p_date_to: rpcParamsWithUser.p_date_to,
-    }
-    const fallback = await supabase.rpc('get_call_logs_with_distinct', params13)
-    if (fallback.error) {
-      console.error('rpc fallback error:', fallback.error)
-      return NextResponse.json({ error: fallback.error.message }, { status: 500 })
-    }
-    data = fallback.data
-    error = null
-  }
+    p_pre_distinct_filters: (body.p_pre_distinct_filters as any[]) ?? [],
+    p_post_distinct_filters: (body.p_post_distinct_filters as any[]) ?? [],
+    p_select: (body.p_select as string) ?? '*',
+    p_order_by_column: (body.p_order_by_column as string) ?? 'created_at',
+    p_order_ascending: (body.p_order_ascending as boolean) ?? false,
+    p_limit: (body.p_limit as number) ?? 50,
+    p_offset: (body.p_offset as number) ?? 0,
+    p_distinct_column: (body.p_distinct_column as string) ?? null,
+    p_distinct_json_field: (body.p_distinct_json_field as string) ?? null,
+    p_distinct_order: (body.p_distinct_order as string) ?? 'asc',
+    p_date_from: (body.p_date_from as string) ?? null,
+    p_date_to: (body.p_date_to as string) ?? null,
+  })
 
   if (error) {
-    console.error('get_call_logs_with_distinct:', error)
+    console.error('queryCallLogs:', error)
     return NextResponse.json({ error: error.message }, { status: 500 })
   }
 

--- a/src/lib/queryCallLogs.ts
+++ b/src/lib/queryCallLogs.ts
@@ -1,0 +1,131 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+type RpcFilter = { column: string; operator: string; value: unknown }
+
+function applyFilters(query: any, filters: RpcFilter[]) {
+  let q = query
+  for (const f of filters) {
+    switch (f.operator) {
+      case 'eq':    q = q.eq(f.column, f.value); break
+      case 'neq':
+      case '<>':    q = q.neq(f.column, f.value); break
+      case 'gt':    q = q.gt(f.column, f.value); break
+      case 'gte':   q = q.gte(f.column, f.value); break
+      case 'lt':    q = q.lt(f.column, f.value); break
+      case 'lte':   q = q.lte(f.column, f.value); break
+      case 'ilike': q = q.ilike(f.column, f.value as string); break
+      case 'like':  q = q.like(f.column, f.value as string); break
+      case 'in':    q = q.in(f.column, f.value as unknown[]); break
+      case 'not.is': q = q.not(f.column, 'is', f.value); break
+    }
+  }
+  return q
+}
+
+export interface CallLogsQueryParams {
+  p_agent_id: string
+  p_pre_distinct_filters: RpcFilter[]
+  p_post_distinct_filters: RpcFilter[]
+  p_select: string
+  p_order_by_column: string
+  p_order_ascending: boolean
+  p_limit: number
+  p_offset: number
+  p_distinct_column: string | null
+  p_distinct_json_field: string | null
+  p_distinct_order: string
+  p_date_from: string | null
+  p_date_to: string | null
+}
+
+export async function queryCallLogs(supabase: SupabaseClient, params: CallLogsQueryParams) {
+  const {
+    p_agent_id,
+    p_pre_distinct_filters,
+    p_post_distinct_filters,
+    p_select,
+    p_order_by_column,
+    p_order_ascending,
+    p_limit,
+    p_offset,
+    p_distinct_column,
+    p_distinct_json_field,
+    p_date_from,
+    p_date_to,
+    p_distinct_order,
+  } = params
+
+  const hasDistinct = !!p_distinct_column
+
+  let query = (supabase as any)
+    .from('pype_voice_call_logs')
+    .select(p_select || '*')
+    .eq('agent_id', p_agent_id)
+
+  if (p_date_from) query = query.gte('call_started_at', `${p_date_from} 00:00:00`)
+  if (p_date_to)   query = query.lte('call_started_at', `${p_date_to} 23:59:59.999`)
+
+  query = applyFilters(query, p_pre_distinct_filters)
+
+  if (!hasDistinct) {
+    query = applyFilters(query, p_post_distinct_filters)
+    query = query.order(p_order_by_column || 'created_at', { ascending: !!p_order_ascending })
+    query = query.range(p_offset, p_offset + p_limit - 1)
+    return query as Promise<{ data: any[] | null; error: any }>
+  }
+
+  // DISTINCT ON is not supported by the PostgREST query builder.
+  // Fetch a broad result set ordered by the distinct column, then deduplicate in JS.
+  if (!p_distinct_json_field) {
+    query = query.order(p_distinct_column!, { ascending: p_distinct_order === 'asc' })
+  }
+  if (p_order_by_column && p_order_by_column !== p_distinct_column) {
+    query = query.order(p_order_by_column, { ascending: !!p_order_ascending })
+  }
+  // Cap the fetch at 10k rows to avoid runaway queries
+  query = query.range(0, 9999)
+
+  const { data, error } = await query
+  if (error) return { data: null as any, error }
+
+  let rows: any[] = data || []
+
+  // Apply post-distinct filters in JS
+  for (const f of p_post_distinct_filters) {
+    rows = filterRowsInJS(rows, f)
+  }
+
+  // Deduplicate keeping the first occurrence (matches DISTINCT ON semantics when ordered)
+  const seen = new Set<string>()
+  const deduped = rows.filter(row => {
+    const raw = p_distinct_json_field
+      ? (row[p_distinct_column!] as any)?.[p_distinct_json_field]
+      : row[p_distinct_column!]
+    const key = String(raw ?? '')
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+
+  return { data: deduped.slice(p_offset, p_offset + p_limit), error: null }
+}
+
+function filterRowsInJS(rows: any[], f: RpcFilter): any[] {
+  return rows.filter(row => {
+    const val = row[f.column as string]
+    switch (f.operator) {
+      case 'eq':    return String(val ?? '') === String(f.value ?? '')
+      case 'neq':
+      case '<>':    return String(val ?? '') !== String(f.value ?? '')
+      case 'gt':    return Number(val) > Number(f.value)
+      case 'gte':   return Number(val) >= Number(f.value)
+      case 'lt':    return Number(val) < Number(f.value)
+      case 'lte':   return Number(val) <= Number(f.value)
+      case 'ilike': return String(val ?? '').toLowerCase().includes(
+                      String(f.value ?? '').replace(/%/g, '').toLowerCase()
+                    )
+      case 'not.is': return val !== null && val !== undefined
+      default:      return true
+    }
+  })
+}


### PR DESCRIPTION
## Problem

Running `setup-supabase.sql` against an existing database produced multiple errors that blocked table creation. This led to cascading failures, including:

* Missing `pype_voice_call_logs`
* Broken materialized views
* Failed foreign key constraints

## Changes

* **`pype_voice_call_logs.duration_seconds`**
  Removed illegal `DEFAULT CASE WHEN ... call_ended_at ... call_started_at ...` expression. PostgreSQL does not allow column references in `DEFAULT` clauses. This caused the entire table creation to fail, which subsequently broke dependent materialized views and foreign key setups.

* **`pype_voice_email_project_mapping`**
  Removed trailing comma after the last column (`is_active boolean`), which caused a syntax error at the closing `)`.

* **`pype_voice_agent_dropoff_settings` (first occurrence)**
  Updated to `CREATE TABLE IF NOT EXISTS`. This table was missing from the top-level `DROP TABLE` cleanup block, causing re-runs to fail with `"relation already exists"`.

* **`pype_voice_metrics_templates`, `pype_voice_phone_numbers`, `pype_voice_webhook_configs`**
  Updated to `CREATE TABLE IF NOT EXISTS` for the same reason: these tables were not included in the cleanup block, making the script non-idempotent.
