### PR TITLE
Move call summary refresh to pg_cron (remove blocking RPC)

### DIFF
--- a/src/app/api/agents/[id]/overview/data/route.ts
+++ b/src/app/api/agents/[id]/overview/data/route.ts
@@ -36,11 +36,6 @@ export async function GET(
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
 
-  const { error: refreshError } = await supabase.rpc('refresh_call_summary')
-  if (refreshError) {
-    return NextResponse.json({ error: refreshError.message }, { status: 500 })
-  }
-
   const { data: dailyStats, error: queryError } = await supabase
     .from('call_summary_materialized')
     .select(


### PR DESCRIPTION
- Removed blocking `refresh_call_summary` RPC call from overview API route
- Added pg_cron job in Supabase to refresh materialized view every 10 minutes
- API now reads precomputed data instead of triggering refresh on each request

Impact:
- Significantly reduces API latency
- Prevents request-time DB load and timeouts
- Data may be up to ~10 minutes stale (acceptable tradeoff)