### PR TITLE
feat: add fallback provider config for STT, TTS, and LLM

### DIFF
--- a/src/app/[projectid]/agents/[agentid]/config/livekit/page.tsx
+++ b/src/app/[projectid]/agents/[agentid]/config/livekit/page.tsx
@@ -1242,7 +1242,7 @@ const unmappedVariablesCount = useMemo(() => {
             <div className="flex-shrink-0 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-3 space-y-3">
               {/* Pipeline mode toggle */}
               <div className="flex items-center justify-between">
-                <span className="text-xs font-medium text-gray-500 dark:text-gray-400">Voice Pipeline</span>
+                
                 <div className="flex items-center bg-gray-100 dark:bg-gray-900 rounded-lg p-0.5 gap-0.5">
                   <button
                     type="button"
@@ -1260,7 +1260,7 @@ const unmappedVariablesCount = useMemo(() => {
                     onClick={enterFallbackMode}
                     className={`px-3 py-1 text-xs font-medium rounded-md transition-all duration-150 ${
                       showFallback
-                        ? 'bg-amber-500 text-white shadow-sm'
+                        ? 'bg-yellow-100 text-black shadow-sm'
                         : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
                     }`}
                   >

--- a/src/app/[projectid]/agents/[agentid]/config/livekit/page.tsx
+++ b/src/app/[projectid]/agents/[agentid]/config/livekit/page.tsx
@@ -260,6 +260,11 @@ export default function AgentConfig() {
     apiVersion: ''
   })
 
+  const [fallbackAzureConfig, setFallbackAzureConfig] = useState<AzureConfig>({
+    endpoint: '',
+    apiVersion: ''
+  })
+
   const [hasExternalChanges, setHasExternalChanges] = useState(false)
 
   const [ttsConfig, setTtsConfig] = useState({
@@ -471,7 +476,8 @@ export default function AgentConfig() {
     currentFormik: formik,
     currentTtsConfig: ttsConfig,
     currentSttConfig: sttConfig,
-    currentAzureConfig: azureConfig
+    currentAzureConfig: azureConfig,
+    fallbackAzureConfig: fallbackAzureConfig
   })
 
   // useEffect(() => {
@@ -521,12 +527,22 @@ export default function AgentConfig() {
       }
       
       if (mappedProvider === 'azure_openai' && assistant.llm) {
-        const azureConfigData = {
+        setAzureConfig({
           endpoint: assistant.llm.azure_endpoint || '',
           apiVersion: assistant.llm.api_version || ''
-        }
-        setAzureConfig(azureConfigData)
+        })
       }
+
+      if (assistant.llm?.fallback) {
+        const fbProvider = assistant.llm.fallback.provider || assistant.llm.fallback.name || ''
+        if (fbProvider === 'azure') {
+          setFallbackAzureConfig({
+            endpoint: assistant.llm.fallback.azure_endpoint || '',
+            apiVersion: assistant.llm.fallback.api_version || ''
+          })
+        }
+      }
+
     }
   }, [agentConfigData])
 
@@ -534,6 +550,7 @@ export default function AgentConfig() {
     if (saveAndDeploy.isSuccess) {
       setHasExternalChanges(false)
       resetUnsavedChanges()
+      setIsFallbackView(false)
       // CRITICAL: Store current values and reset to clear dirty flag
       const currentValues = formik.values
       formik.resetForm()
@@ -543,18 +560,21 @@ export default function AgentConfig() {
 
   const handleApplyPastedConfig = (config: DeserializedConfig) => {
     console.log('📋 Applying pasted configuration:', config)
-    
+
     // Apply formik values
     formik.setValues(config.formikValues, false) // false = don't validate immediately
-    
+
     // Apply external state
     setTtsConfig(config.ttsConfig)
     setSTTConfig(config.sttConfig)
     setAzureConfig(config.azureConfig)
-    
+    if (config.fallbackAzureConfig) {
+      setFallbackAzureConfig(config.fallbackAzureConfig)
+    }
+
     // Mark form as dirty to enable save
     setHasExternalChanges(true)
-    
+
     console.log('✅ Configuration applied successfully')
   }
 
@@ -627,10 +647,23 @@ export default function AgentConfig() {
     formik.setFieldValue('sttProvider', provider)
     formik.setFieldValue('sttModel', model)
     formik.setFieldValue('sttConfig', config)
-    
+
     setSTTConfig({ provider, model, config })
   }
-  
+
+  const handleFallbackSTTSelect = (provider: string, model: string, config: any) => {
+    formik.setFieldValue('fallbackSttProvider', provider)
+    formik.setFieldValue('fallbackSttModel', model)
+    formik.setFieldValue('fallbackSttConfig', config)
+  }
+
+  const handleFallbackVoiceSelect = (voiceId: string, provider: string, model?: string, config?: any) => {
+    formik.setFieldValue('fallbackTtsVoiceId', voiceId)
+    formik.setFieldValue('fallbackTtsProvider', provider)
+    formik.setFieldValue('fallbackTtsModel', model || '')
+    formik.setFieldValue('fallbackTtsVoiceConfig', config || {})
+  }
+
   const handleProviderChange = (provider: string) => {
     formik.setFieldValue('selectedProvider', provider)
   }
@@ -645,6 +678,23 @@ export default function AgentConfig() {
 
   const handleAzureConfigChange = (config: AzureConfig) => {
     setAzureConfig(config)
+    setHasExternalChanges(true)
+  }
+
+  const handleFallbackProviderChange = (provider: string) => {
+    formik.setFieldValue('fallbackLlmProvider', provider)
+  }
+
+  const handleFallbackModelChange = (model: string) => {
+    formik.setFieldValue('fallbackLlmModel', model)
+  }
+
+  const handleFallbackTemperatureChange = (temperature: number) => {
+    formik.setFieldValue('fallbackLlmTemperature', temperature)
+  }
+
+  const handleFallbackAzureConfigChange = (config: AzureConfig) => {
+    setFallbackAzureConfig(config)
     setHasExternalChanges(true)
   }
 
@@ -706,6 +756,26 @@ const unmappedVariablesCount = useMemo(() => {
   })
   return unmapped.length
 }, [promptValidation.validVariables, formik.values.variables])
+
+  // View-only toggle: controls which selectors are displayed.
+  // NEVER clears the fallbackXxxEnabled Formik flags — that was the root bug:
+  // clicking "Primary" would set all flags false and the next Save would silently
+  // erase all configured fallbacks from the backend config.
+  const [isFallbackView, setIsFallbackView] = useState(false)
+
+  // showFallback = which panel is currently displayed (alias for readability below)
+  const showFallback = isFallbackView
+
+  const enterPrimaryMode = () => setIsFallbackView(false)
+
+  const enterFallbackMode = () => {
+    setIsFallbackView(true)
+    // Mark all three enabled so buildSavePayload will include them if a provider is set.
+    // Ones with an empty provider are still excluded by the &&-provider guard in buildSavePayload.
+    formik.setFieldValue('fallbackSttEnabled', true)
+    formik.setFieldValue('fallbackTtsEnabled', true)
+    formik.setFieldValue('fallbackLlmEnabled', true)
+  }
 
   const isFormDirty = formik.dirty || hasExternalChanges || hasMultiAssistantChanges
   const isBackendUnavailable = !!agentConfigData?.backendUnavailable
@@ -1148,38 +1218,103 @@ const unmappedVariablesCount = useMemo(() => {
           <div className="flex-1 min-w-0 flex flex-col space-y-3">
             
             {/* Quick Setup Row */}
-            <div className="flex flex-col sm:flex-row gap-3 flex-shrink-0">
-              <div className="flex-1 min-w-0">
-                <ModelSelector
-                  selectedProvider={formik.values.selectedProvider}
-                  selectedModel={formik.values.selectedModel}
-                  temperature={formik.values.temperature}
-                  onProviderChange={handleProviderChange}
-                  onModelChange={handleModelChange}
-                  onTemperatureChange={handleTemperatureChange}
-                  azureConfig={azureConfig}
-                  onAzureConfigChange={handleAzureConfigChange}
-                />
+            <div className="flex-shrink-0 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-3 space-y-3">
+              {/* Pipeline mode toggle */}
+              <div className="flex items-center justify-between">
+                <span className="text-xs font-medium text-gray-500 dark:text-gray-400">Voice Pipeline</span>
+                <div className="flex items-center bg-gray-100 dark:bg-gray-900 rounded-lg p-0.5 gap-0.5">
+                  <button
+                    type="button"
+                    onClick={enterPrimaryMode}
+                    className={`px-3 py-1 text-xs font-medium rounded-md transition-all duration-150 ${
+                      !showFallback
+                        ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm'
+                        : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+                    }`}
+                  >
+                    Primary
+                  </button>
+                  <button
+                    type="button"
+                    onClick={enterFallbackMode}
+                    className={`px-3 py-1 text-xs font-medium rounded-md transition-all duration-150 ${
+                      showFallback
+                        ? 'bg-amber-500 text-white shadow-sm'
+                        : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+                    }`}
+                  >
+                    Fallback
+                  </button>
+                </div>
               </div>
 
-              <div className="flex-1 min-w-0">
-                <SelectSTT 
-                  selectedProvider={formik.values.sttProvider}
-                  selectedModel={formik.values.sttModel}
-                  selectedLanguage={formik.values.sttConfig?.language}   
-                  initialConfig={formik.values.sttConfig}                
-                  onSTTSelect={handleSTTSelect}
-                />
-              </div>
+              {/* Selectors */}
+              <div className="flex flex-col sm:flex-row gap-3">
+                <div className="flex-1 min-w-0">
+                  {!showFallback ? (
+                    <ModelSelector
+                      selectedProvider={formik.values.selectedProvider}
+                      selectedModel={formik.values.selectedModel}
+                      temperature={formik.values.temperature}
+                      onProviderChange={handleProviderChange}
+                      onModelChange={handleModelChange}
+                      onTemperatureChange={handleTemperatureChange}
+                      azureConfig={azureConfig}
+                      onAzureConfigChange={handleAzureConfigChange}
+                    />
+                  ) : (
+                    <ModelSelector
+                      selectedProvider={formik.values.fallbackLlmProvider}
+                      selectedModel={formik.values.fallbackLlmModel}
+                      temperature={formik.values.fallbackLlmTemperature}
+                      onProviderChange={handleFallbackProviderChange}
+                      onModelChange={handleFallbackModelChange}
+                      onTemperatureChange={handleFallbackTemperatureChange}
+                      azureConfig={fallbackAzureConfig}
+                      onAzureConfigChange={handleFallbackAzureConfigChange}
+                    />
+                  )}
+                </div>
 
-              <div className="flex-1 min-w-0">
-                <SelectTTS 
-                  selectedVoice={formik.values.selectedVoice}
-                  initialProvider={formik.values.ttsProvider}
-                  initialModel={formik.values.ttsModel}
-                  initialConfig={formik.values.ttsVoiceConfig}
-                  onVoiceSelect={handleVoiceSelect}
-                />
+                <div className="flex-1 min-w-0">
+                  {!showFallback ? (
+                    <SelectSTT
+                      selectedProvider={formik.values.sttProvider}
+                      selectedModel={formik.values.sttModel}
+                      selectedLanguage={formik.values.sttConfig?.language}
+                      initialConfig={formik.values.sttConfig}
+                      onSTTSelect={handleSTTSelect}
+                    />
+                  ) : (
+                    <SelectSTT
+                      selectedProvider={formik.values.fallbackSttProvider}
+                      selectedModel={formik.values.fallbackSttModel}
+                      selectedLanguage={formik.values.fallbackSttConfig?.language}
+                      initialConfig={formik.values.fallbackSttConfig}
+                      onSTTSelect={handleFallbackSTTSelect}
+                    />
+                  )}
+                </div>
+
+                <div className="flex-1 min-w-0">
+                  {!showFallback ? (
+                    <SelectTTS
+                      selectedVoice={formik.values.selectedVoice}
+                      initialProvider={formik.values.ttsProvider}
+                      initialModel={formik.values.ttsModel}
+                      initialConfig={formik.values.ttsVoiceConfig}
+                      onVoiceSelect={handleVoiceSelect}
+                    />
+                  ) : (
+                    <SelectTTS
+                      selectedVoice={formik.values.fallbackTtsVoiceId}
+                      initialProvider={formik.values.fallbackTtsProvider}
+                      initialModel={formik.values.fallbackTtsModel}
+                      initialConfig={formik.values.fallbackTtsVoiceConfig}
+                      onVoiceSelect={handleFallbackVoiceSelect}
+                    />
+                  )}
+                </div>
               </div>
             </div>
 
@@ -1471,6 +1606,7 @@ const unmappedVariablesCount = useMemo(() => {
         ttsConfig={ttsConfig}
         sttConfig={sttConfig}
         azureConfig={azureConfig}
+        fallbackAzureConfig={fallbackAzureConfig}
       />
 
       <PasteConfigDialog

--- a/src/components/agents/AgentConfig/CopyConfigDialog.tsx
+++ b/src/components/agents/AgentConfig/CopyConfigDialog.tsx
@@ -21,6 +21,7 @@ interface CopyConfigDialogProps {
   ttsConfig: any
   sttConfig: any
   azureConfig: any
+  fallbackAzureConfig?: any
 }
 
 export default function CopyConfigDialog({
@@ -29,7 +30,8 @@ export default function CopyConfigDialog({
   formikValues,
   ttsConfig,
   sttConfig,
-  azureConfig
+  azureConfig,
+  fallbackAzureConfig
 }: CopyConfigDialogProps) {
   const [configJson, setConfigJson] = useState<string>('')
   const [isCopied, setIsCopied] = useState(false)
@@ -46,7 +48,8 @@ export default function CopyConfigDialog({
           formikValues,
           ttsConfig,
           sttConfig,
-          azureConfig
+          azureConfig,
+          fallbackAzureConfig
         )
         const prettyJson = prettyPrintConfig(serialized)
         setConfigJson(prettyJson)

--- a/src/components/agents/AgentConfig/SelectTTSDialog/index.tsx
+++ b/src/components/agents/AgentConfig/SelectTTSDialog/index.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Badge } from '@/components/ui/badge'
-import { Volume2, Sparkles, Settings, RotateCcw } from 'lucide-react'
+import { Volume2, Sparkles, Settings, RotateCcw, AlertTriangle } from 'lucide-react'
 
 import VoiceSelectionPanel from './VoiceSelectionPanel'
 import SettingsPanel from './SettingsPanel'
@@ -473,8 +473,31 @@ function SelectTTS({ selectedVoice, initialProvider, initialModel, initialConfig
     setIsOpen(false)
   }
 
+  const isElevenLabsProvider = initialProvider === 'elevenlabs' || currentProvider === 'elevenlabs'
+
+  // True when ElevenLabs key is invalid and the configured voice is an ElevenLabs voice
+  // (or the provider is explicitly set to ElevenLabs)
+  const isVoiceInputError = !!(
+    elevenLabsError && (
+      isElevenLabsProvider ||
+      (selectedVoice &&
+        !allSarvamVoices.some(v => v.id === selectedVoice) &&
+        !googleTTSVoices.some(v => v.name === selectedVoice))
+    )
+  )
+
   const getSelectedVoiceName = () => {
-    if (selectedVoice && (!elevenLabsFetched || isLoadingElevenLabs)) {
+    // Check Sarvam first — hardcoded list, never needs ElevenLabs API
+    if (selectedVoice) {
+      const sarvamVoice = allSarvamVoices.find(v => v.id === selectedVoice)
+      if (sarvamVoice) return sarvamVoice.name
+
+      const googleTTSVoice = googleTTSVoices.find(v => v.name === selectedVoice)
+      if (googleTTSVoice) return googleTTSVoice.displayName
+    }
+
+    // ElevenLabs path — requires API key
+    if (isLoadingElevenLabs && selectedVoice) {
       return (
         <div className="flex items-center gap-2">
           <Skeleton className="w-3 h-3" />
@@ -482,15 +505,23 @@ function SelectTTS({ selectedVoice, initialProvider, initialModel, initialConfig
         </div>
       )
     }
-    
+
+    // API unavailable — if a voice is configured show a stable label so the user
+    // knows there IS a voice stored; only show "No Input" when no voice was selected
+    if (elevenLabsError) {
+      if (selectedVoice) {
+        return "ElevenLabs Voice"
+      }
+      if (isElevenLabsProvider) {
+        return "No Input"
+      }
+    }
+
     if (!selectedVoice) return "Choose Voice"
-    
-    const sarvamVoice = allSarvamVoices.find(v => v.id === selectedVoice)
-    if (sarvamVoice) return sarvamVoice.name
+
     const elevenLabsVoice = elevenLabsVoices.find(v => v.voice_id === selectedVoice)
     if (elevenLabsVoice) return elevenLabsVoice.name
-    const googleTTSVoice = googleTTSVoices.find(v => v.name === selectedVoice)
-    if (googleTTSVoice) return googleTTSVoice.displayName
+
     return "Voice Selected"
   }
 
@@ -498,8 +529,19 @@ function SelectTTS({ selectedVoice, initialProvider, initialModel, initialConfig
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
       <DialogTrigger asChild>
-        <Button variant="outline" size="sm" className="justify-start text-xs font-normal w-full text-ellipsis overflow-hidden">
-          <Volume2 className="w-3.5 h-3.5 mr-2" />
+        <Button
+          variant="outline"
+          size="sm"
+          className={`justify-start text-xs font-normal w-full text-ellipsis overflow-hidden ${
+            isVoiceInputError
+              ? 'border-amber-400 dark:border-amber-600 text-amber-600 dark:text-amber-400 hover:border-amber-500'
+              : ''
+          }`}
+        >
+          {isVoiceInputError
+            ? <AlertTriangle className="w-3.5 h-3.5 mr-2 text-amber-500 flex-shrink-0" />
+            : <Volume2 className="w-3.5 h-3.5 mr-2 flex-shrink-0" />
+          }
           {getSelectedVoiceName()}
         </Button>
       </DialogTrigger>

--- a/src/config/agentDefaults.ts
+++ b/src/config/agentDefaults.ts
@@ -193,7 +193,26 @@ export const AGENT_DEFAULT_CONFIG = {
     silenceTime: 10,
     // Dynamic TTS routing
     dynamic_tts: [],
-  
+
+    // STT Fallback
+    fallbackSttEnabled: false,
+    fallbackSttProvider: '',
+    fallbackSttModel: '',
+    fallbackSttConfig: {} as any,
+
+    // TTS Fallback
+    fallbackTtsEnabled: false,
+    fallbackTtsProvider: '',
+    fallbackTtsModel: '',
+    fallbackTtsVoiceId: '',
+    fallbackTtsVoiceConfig: {} as any,
+
+    // LLM Fallback
+    fallbackLlmEnabled: false,
+    fallbackLlmProvider: '',
+    fallbackLlmModel: '',
+    fallbackLlmTemperature: 0.3 as number,
+
     // Advanced Settings
     advancedSettings: {
       interruption: {
@@ -257,6 +276,9 @@ export const AGENT_DEFAULT_CONFIG = {
         bugEndCommands: [...AGENT_DEFAULT_CONFIG.bug_reports.bug_end_command],
         initialResponse: AGENT_DEFAULT_CONFIG.bug_reports.response,
         collectionPrompt: AGENT_DEFAULT_CONFIG.bug_reports.collection_prompt
+      },
+      contextMemory: {
+        enabled: AGENT_DEFAULT_CONFIG.context_memory.enabled
       },
       backgroundAudio: {
         mode: 'dual' as 'disabled' | 'single' | 'dual',

--- a/src/hooks/useAgentConfig.ts
+++ b/src/hooks/useAgentConfig.ts
@@ -21,11 +21,22 @@ export interface AgentConfigResponse {
         api_version?: string
         azure_deployment?: string
         api_key_env?: string
+        fallback?: {
+          model?: string
+          provider?: string
+          name?: string
+          temperature?: number
+          azure_endpoint?: string
+          api_version?: string
+          azure_deployment?: string
+          api_key_env?: string
+        }
       }
       tts?: {
         name: string
         model: string
         voice_id?: string
+        voice_name?: string
         speaker?: string
         language?: string
         target_language_code?: string
@@ -38,6 +49,29 @@ export interface AgentConfigResponse {
           style: number
           use_speaker_boost: boolean
           speed: number
+          pace?: number
+          loudness?: number
+          enable_preprocessing?: boolean
+          pitch?: number
+        }
+        fallback?: {
+          name: string
+          model?: string
+          voice_id?: string
+          voice_name?: string
+          language?: string
+          target_language_code?: string
+          gender?: string
+          voice_settings?: Record<string, any>
+          pace?: number
+          loudness?: number
+          enable_preprocessing?: boolean
+          pitch?: number
+          similarityBoost?: number
+          stability?: number
+          style?: number
+          useSpeakerBoost?: boolean
+          speed?: number
         }
       }
       stt?: {
@@ -46,6 +80,12 @@ export interface AgentConfigResponse {
         model?: string
         language?: string
         config?: Record<string, any>
+        fallback?: {
+          name: string
+          model?: string
+          language?: string
+          mode?: string
+        }
       }
       vad?: {
         name: string
@@ -448,6 +488,55 @@ export const buildFormValuesFromAgent = (assistant: any) => {
       ...(assistant.stt?.config || {}),
     },
     dynamic_tts: assistant.dynamic_tts || [],
+    fallbackSttEnabled: !!(assistant.stt?.fallback),
+    fallbackSttProvider: assistant.stt?.fallback?.name || '',
+    fallbackSttModel: assistant.stt?.fallback?.model || '',
+    fallbackSttConfig: assistant.stt?.fallback || {},
+    fallbackTtsEnabled: !!(assistant.tts?.fallback),
+    fallbackTtsProvider: assistant.tts?.fallback?.name || '',
+    fallbackTtsModel: assistant.tts?.fallback?.model || '',
+    // Google uses voice_name; ElevenLabs uses voice_id
+    fallbackTtsVoiceId: assistant.tts?.fallback?.voice_id || assistant.tts?.fallback?.voice_name || '',
+    // Normalize to the same camelCase shape that SelectTTS and buildFallbackTtsPayload expect.
+    // Without this, every re-save after a reload would reset all voice settings to defaults.
+    fallbackTtsVoiceConfig: (() => {
+      const fb = assistant.tts?.fallback
+      if (!fb) return {}
+      const name = fb.name
+      if (name === 'sarvam' || name === 'sarvam_tts') {
+        return {
+          target_language_code: fb.target_language_code || fb.language || 'en-IN',
+          pace: fb.voice_settings?.pace ?? fb.pace ?? fb.voice_settings?.speed ?? fb.speed ?? 1.0,
+          loudness: fb.voice_settings?.loudness ?? fb.loudness ?? 1.0,
+          enable_preprocessing: fb.voice_settings?.enable_preprocessing ?? fb.enable_preprocessing ?? true,
+          pitch: fb.voice_settings?.pitch ?? fb.pitch ?? 0.0,
+        }
+      }
+      if (name === 'google') {
+        return {
+          voice_name: fb.voice_name || fb.voice_id || '',
+          gender: fb.gender,
+        }
+      }
+      // ElevenLabs or any other provider
+      return {
+        voiceId: fb.voice_id || '',
+        language: fb.language || 'en',
+        similarityBoost: fb.voice_settings?.similarity_boost ?? fb.similarityBoost ?? 0.75,
+        stability: fb.voice_settings?.stability ?? fb.stability ?? 0.5,
+        style: fb.voice_settings?.style ?? fb.style ?? 0,
+        useSpeakerBoost: fb.voice_settings?.use_speaker_boost ?? fb.useSpeakerBoost ?? true,
+        speed: fb.voice_settings?.speed ?? fb.speed ?? 1.0,
+      }
+    })(),
+    fallbackLlmEnabled: !!(assistant.llm?.fallback),
+    fallbackLlmProvider: (() => {
+      const fp = assistant.llm?.fallback?.provider || assistant.llm?.fallback?.name || ''
+      if (fp === 'azure') return 'azure_openai'
+      return fp
+    })(),
+    fallbackLlmModel: assistant.llm?.fallback?.model || '',
+    fallbackLlmTemperature: assistant.llm?.fallback?.temperature ?? 0.3,
     advancedSettings: {
       interruption: {
         allowInterruptions: assistant.interruptions?.allow_interruptions ?? assistant.allow_interruptions ?? getFallback(null, 'interruptions.allow_interruptions'),

--- a/src/hooks/useMultiAssistantState.ts
+++ b/src/hooks/useMultiAssistantState.ts
@@ -3,6 +3,58 @@ import { useState, useCallback, useMemo, useEffect, useRef } from 'react'
 import { FormikProps } from 'formik'
 import { getFallback } from '@/config/agentDefaults'
 
+function buildFallbackTtsPayload(formValues: any) {
+  const provider = formValues.fallbackTtsProvider
+  // cfg is either already normalized (camelCase from SelectTTS) or raw (snake_case from backend).
+  // All lookups try the normalized key first, then fall back to voice_settings nested format.
+  const cfg = formValues.fallbackTtsVoiceConfig || {}
+
+  if (provider === 'sarvam' || provider === 'sarvam_tts') {
+    return {
+      name: provider,
+      voice_id: formValues.fallbackTtsVoiceId,
+      model: formValues.fallbackTtsModel,
+      language: cfg.target_language_code || cfg.language || 'en-IN',
+      voice_settings: {
+        similarity_boost: 1,
+        stability: 0.8,
+        style: 1,
+        use_speaker_boost: true,
+        // SelectTTS uses `pace`; saved backend config uses `voice_settings.speed`
+        speed: cfg.pace ?? cfg.speed ?? cfg.voice_settings?.pace ?? cfg.voice_settings?.speed ?? 1.0,
+        loudness: cfg.loudness ?? cfg.voice_settings?.loudness ?? 1.0,
+        enable_preprocessing: cfg.enable_preprocessing ?? cfg.voice_settings?.enable_preprocessing ?? true,
+        pitch: cfg.pitch ?? cfg.voice_settings?.pitch ?? 0.0,
+      },
+    }
+  } else if (provider === 'google') {
+    const result: any = {
+      name: 'google',
+      voice_name: formValues.fallbackTtsVoiceId || cfg.voice_name,
+    }
+    if (cfg.gender && cfg.gender !== 'none') {
+      result.gender = cfg.gender.toLowerCase()
+    }
+    return result
+  } else {
+    // ElevenLabs or any other provider
+    // Normalized keys (camelCase) are tried first; raw voice_settings keys are tried as fallback
+    return {
+      name: provider,
+      voice_id: formValues.fallbackTtsVoiceId,
+      model: formValues.fallbackTtsModel,
+      language: cfg.language || 'en',
+      voice_settings: {
+        similarity_boost: cfg.similarityBoost ?? cfg.voice_settings?.similarity_boost ?? 0.75,
+        stability: cfg.stability ?? cfg.voice_settings?.stability ?? 0.5,
+        style: cfg.style ?? cfg.voice_settings?.style ?? 0,
+        use_speaker_boost: cfg.useSpeakerBoost ?? cfg.voice_settings?.use_speaker_boost ?? true,
+        speed: cfg.speed ?? cfg.voice_settings?.speed ?? 1.0,
+      },
+    }
+  }
+}
+
 interface AssistantFormData {
   name: string
   formikRef?: FormikProps<any> | null
@@ -22,17 +74,19 @@ interface UseMultiAssistantStateProps {
   currentTtsConfig?: any
   currentSttConfig?: any
   currentAzureConfig?: any
+  fallbackAzureConfig?: any
 }
 
-export function useMultiAssistantState({ 
-  initialAssistants, 
-  agentId, 
+export function useMultiAssistantState({
+  initialAssistants,
+  agentId,
   agentName,
   agentType = 'OUTBOUND',
   currentFormik,
   currentTtsConfig,
   currentSttConfig,
-  currentAzureConfig
+  currentAzureConfig,
+  fallbackAzureConfig
 }: UseMultiAssistantStateProps) {
   
   const [assistantNames, setAssistantNames] = useState<string[]>(() => {
@@ -146,7 +200,15 @@ export function useMultiAssistantState({
           model: currentSttConfig?.model || formValues.sttModel || getFallback(null, 'stt.model'),
           ...(( currentSttConfig?.config?.mode || formValues.sttConfig?.mode) && {
             mode: currentSttConfig?.config?.mode || formValues.sttConfig?.mode
-          })
+          }),
+          ...(formValues.fallbackSttEnabled && formValues.fallbackSttProvider && {
+            fallback: {
+              name: formValues.fallbackSttProvider,
+              language: formValues.fallbackSttConfig?.language || formValues.sttConfig?.language || getFallback(null, 'stt.language'),
+              model: formValues.fallbackSttModel,
+              ...(formValues.fallbackSttConfig?.mode && { mode: formValues.fallbackSttConfig.mode }),
+            }
+          }),
         },
         llm: {
           name: formValues.selectedProvider || getFallback(null, 'llm.name'),
@@ -159,55 +221,72 @@ export function useMultiAssistantState({
             api_version: currentAzureConfig.apiVersion || getFallback(null, 'llm.api_version'),
             api_key_env: getFallback(null, 'llm.api_key_env')
           }),
-          ...(formValues.selectedProvider === 'openai' && {
-            api_key_env: 'OPENAI_API_KEY'
+          ...(formValues.selectedProvider === 'openai' && { api_key_env: 'OPENAI_API_KEY' }),
+          ...(formValues.selectedProvider === 'groq' && { api_key_env: 'GROQ_API_KEY' }),
+          ...(formValues.selectedProvider === 'cerebras' && { api_key_env: 'CEREBRAS_API_KEY' }),
+          ...(formValues.fallbackLlmEnabled && formValues.fallbackLlmProvider && {
+            fallback: {
+              name: formValues.fallbackLlmProvider,
+              provider: formValues.fallbackLlmProvider === 'azure_openai' ? 'azure' : formValues.fallbackLlmProvider,
+              model: formValues.fallbackLlmModel || getFallback(null, 'llm.model'),
+              temperature: formValues.fallbackLlmTemperature ?? getFallback(null, 'llm.temperature'),
+              ...(formValues.fallbackLlmProvider === 'azure_openai' && fallbackAzureConfig && {
+                azure_deployment: getFallback(null, 'llm.azure_deployment'),
+                azure_endpoint: fallbackAzureConfig.endpoint || getFallback(null, 'llm.azure_endpoint'),
+                api_version: fallbackAzureConfig.apiVersion || getFallback(null, 'llm.api_version'),
+                api_key_env: getFallback(null, 'llm.api_key_env')
+              }),
+              ...(formValues.fallbackLlmProvider === 'openai' && { api_key_env: 'OPENAI_API_KEY' }),
+              ...(formValues.fallbackLlmProvider === 'groq' && { api_key_env: 'GROQ_API_KEY' }),
+              ...(formValues.fallbackLlmProvider === 'cerebras' && { api_key_env: 'CEREBRAS_API_KEY' }),
+            }
           }),
-          ...(formValues.selectedProvider === 'groq' && {
-            api_key_env: 'GROQ_API_KEY'
-          }),
-          ...(formValues.selectedProvider === 'cerebras' && {
-            api_key_env: 'CEREBRAS_API_KEY'
-          })
         },
         tts: (() => {
           const ttsProvider = currentTtsConfig?.provider || formValues.ttsProvider || getFallback(null, 'tts.name')
           const isSarvam = ttsProvider === 'sarvam' || ttsProvider === 'sarvam_tts'
           const isGoogle = ttsProvider === 'google'
           
+          const fallbackTtsPayload = formValues.fallbackTtsEnabled && formValues.fallbackTtsProvider && formValues.fallbackTtsVoiceId
+            ? { fallback: buildFallbackTtsPayload(formValues) }
+            : {}
+
           if (isSarvam) {
             // Sarvam TTS configuration - using ElevenLabs format
             const targetLanguageCode = currentTtsConfig?.config?.target_language_code || formValues.ttsVoiceConfig?.target_language_code || 'en-IN'
             const sarvamSpeed = currentTtsConfig?.config?.speed ?? formValues.ttsVoiceConfig?.speed ?? 1.0
             const sarvamLoudness = currentTtsConfig?.config?.loudness ?? formValues.ttsVoiceConfig?.loudness ?? 1.0
-            
+
             return {
               name: ttsProvider,
               voice_id: formValues.selectedVoice || getFallback(null, 'tts.voice_id'),
               model: currentTtsConfig?.model || formValues.ttsModel || getFallback(null, 'tts.model'),
-              language: targetLanguageCode, // Map target_language_code to language
+              language: targetLanguageCode,
               voice_settings: {
-                similarity_boost: 1, // Default for Sarvam
-                stability: 0.8, // Default for Sarvam
-                style: 1, // Default for Sarvam
-                use_speaker_boost: true, // Default for Sarvam
-                speed: sarvamSpeed, // Map speed from Sarvam config
-                loudness: sarvamLoudness, // Include loudness in voice_settings
+                similarity_boost: 1,
+                stability: 0.8,
+                style: 1,
+                use_speaker_boost: true,
+                speed: sarvamSpeed,
+                loudness: sarvamLoudness,
                 enable_preprocessing: currentTtsConfig?.config?.enable_preprocessing ?? formValues.ttsVoiceConfig?.enable_preprocessing ?? true
-              }
+              },
+              ...fallbackTtsPayload,
             }
           } else if (isGoogle) {
             // Google TTS configuration - only send voice_name and gender (lowercase)
             const googleConfig = currentTtsConfig?.config || formValues.ttsVoiceConfig || {}
             const result: any = {
               name: 'google',
-              voice_name: formValues.selectedVoice || googleConfig.voice_name || getFallback(null, 'tts.voice_name')
+              voice_name: formValues.selectedVoice || googleConfig.voice_name || getFallback(null, 'tts.voice_name'),
+              ...fallbackTtsPayload,
             }
-            
+
             // Only add gender if it's specified, and convert to lowercase
             if (googleConfig.gender && googleConfig.gender !== 'none') {
               result.gender = googleConfig.gender.toLowerCase()
             }
-            
+
             return result
           } else {
             // ElevenLabs or other TTS configuration
@@ -222,7 +301,8 @@ export function useMultiAssistantState({
                 style: currentTtsConfig?.config?.style ?? formValues.ttsVoiceConfig?.style ?? getFallback(null, 'tts.voice_settings.style'),
                 use_speaker_boost: currentTtsConfig?.config?.useSpeakerBoost ?? formValues.ttsVoiceConfig?.useSpeakerBoost ?? getFallback(null, 'tts.voice_settings.use_speaker_boost'),
                 speed: currentTtsConfig?.config?.speed ?? formValues.ttsVoiceConfig?.speed ?? getFallback(null, 'tts.voice_settings.speed')
-              }
+              },
+              ...fallbackTtsPayload,
             }
           }
         })(),
@@ -546,15 +626,26 @@ export function useMultiAssistantState({
             api_version: currentAzureConfig.apiVersion || getFallback(null, 'llm.api_version'),
             api_key_env: getFallback(null, 'llm.api_key_env')
           }),
-          ...(formValues.selectedProvider === 'openai' && {
-            api_key_env: 'OPENAI_API_KEY'
+          ...(formValues.selectedProvider === 'openai' && { api_key_env: 'OPENAI_API_KEY' }),
+          ...(formValues.selectedProvider === 'groq' && { api_key_env: 'GROQ_API_KEY' }),
+          ...(formValues.selectedProvider === 'cerebras' && { api_key_env: 'CEREBRAS_API_KEY' }),
+          ...(formValues.fallbackLlmEnabled && formValues.fallbackLlmProvider && {
+            fallback: {
+              name: formValues.fallbackLlmProvider,
+              provider: formValues.fallbackLlmProvider === 'azure_openai' ? 'azure' : formValues.fallbackLlmProvider,
+              model: formValues.fallbackLlmModel || getFallback(null, 'llm.model'),
+              temperature: formValues.fallbackLlmTemperature ?? getFallback(null, 'llm.temperature'),
+              ...(formValues.fallbackLlmProvider === 'azure_openai' && fallbackAzureConfig && {
+                azure_deployment: getFallback(null, 'llm.azure_deployment'),
+                azure_endpoint: fallbackAzureConfig.endpoint || getFallback(null, 'llm.azure_endpoint'),
+                api_version: fallbackAzureConfig.apiVersion || getFallback(null, 'llm.api_version'),
+                api_key_env: getFallback(null, 'llm.api_key_env')
+              }),
+              ...(formValues.fallbackLlmProvider === 'openai' && { api_key_env: 'OPENAI_API_KEY' }),
+              ...(formValues.fallbackLlmProvider === 'groq' && { api_key_env: 'GROQ_API_KEY' }),
+              ...(formValues.fallbackLlmProvider === 'cerebras' && { api_key_env: 'CEREBRAS_API_KEY' }),
+            }
           }),
-          ...(formValues.selectedProvider === 'groq' && {
-            api_key_env: 'GROQ_API_KEY'
-          }),
-          ...(formValues.selectedProvider === 'cerebras' && {
-            api_key_env: 'CEREBRAS_API_KEY'
-          })
         },
         tts: {
           name: data.ttsConfig?.name || formValues.ttsProvider || getFallback(null, 'tts.name'),
@@ -812,14 +903,15 @@ export function useMultiAssistantState({
     }
   }, [
     assistantNames, 
-    assistantsData, 
-    getAssistantData, 
-    agentName, 
+    assistantsData,
+    getAssistantData,
+    agentName,
     agentType,
     currentFormik,
     currentTtsConfig,
     currentSttConfig,
-    currentAzureConfig
+    currentAzureConfig,
+    fallbackAzureConfig
   ])
 
   const registerFormikRef = useCallback((assistantName: string, formikRef: FormikProps<any>) => {

--- a/src/utils/agentConfigSerializer.ts
+++ b/src/utils/agentConfigSerializer.ts
@@ -25,6 +25,31 @@ export interface SerializedAgentConfig {
       model: string
       config: any
     }
+    fallback: {
+      llm: {
+        enabled: boolean
+        provider: string
+        model: string
+        temperature: number
+        azureConfig?: {
+          endpoint: string
+          apiVersion: string
+        }
+      }
+      tts: {
+        enabled: boolean
+        provider: string
+        model: string
+        voiceId: string
+        voiceConfig: any
+      }
+      stt: {
+        enabled: boolean
+        provider: string
+        model: string
+        config: any
+      }
+    }
     prompt: {
       text: string
       variables: Array<{
@@ -123,6 +148,10 @@ export interface DeserializedConfig {
     endpoint: string
     apiVersion: string
   }
+  fallbackAzureConfig: {
+    endpoint: string
+    apiVersion: string
+  }
 }
 
 export interface ValidationResult {
@@ -139,7 +168,8 @@ export function serializeConfig(
   formikValues: any,
   ttsConfig: any,
   sttConfig: any,
-  azureConfig: any
+  azureConfig: any,
+  fallbackAzureConfig?: any
 ): SerializedAgentConfig {
   return {
     version: CURRENT_VERSION,
@@ -179,6 +209,33 @@ export function serializeConfig(
         silenceTime: formikValues.silenceTime || 10
       },
       dynamicTTS: formikValues.dynamic_tts || [],
+      fallback: {
+        llm: {
+          enabled: !!formikValues.fallbackLlmEnabled,
+          provider: formikValues.fallbackLlmProvider || '',
+          model: formikValues.fallbackLlmModel || '',
+          temperature: formikValues.fallbackLlmTemperature ?? 0.3,
+          ...(formikValues.fallbackLlmProvider === 'azure_openai' && fallbackAzureConfig ? {
+            azureConfig: {
+              endpoint: fallbackAzureConfig.endpoint || '',
+              apiVersion: fallbackAzureConfig.apiVersion || ''
+            }
+          } : {})
+        },
+        tts: {
+          enabled: !!formikValues.fallbackTtsEnabled,
+          provider: formikValues.fallbackTtsProvider || '',
+          model: formikValues.fallbackTtsModel || '',
+          voiceId: formikValues.fallbackTtsVoiceId || '',
+          voiceConfig: formikValues.fallbackTtsVoiceConfig || {}
+        },
+        stt: {
+          enabled: !!formikValues.fallbackSttEnabled,
+          provider: formikValues.fallbackSttProvider || '',
+          model: formikValues.fallbackSttModel || '',
+          config: formikValues.fallbackSttConfig || {}
+        }
+      },
       advancedSettings: formikValues.advancedSettings || {
         interruption: {
           allowInterruptions: true,
@@ -280,6 +337,22 @@ export function deserializeConfig(json: string): DeserializedConfig {
 
       dynamic_tts:      config.dynamicTTS,
       advancedSettings: config.advancedSettings,
+
+      fallbackLlmEnabled:    config.fallback?.llm?.enabled ?? false,
+      fallbackLlmProvider:   config.fallback?.llm?.provider || '',
+      fallbackLlmModel:      config.fallback?.llm?.model || '',
+      fallbackLlmTemperature: config.fallback?.llm?.temperature ?? 0.3,
+
+      fallbackTtsEnabled:    config.fallback?.tts?.enabled ?? false,
+      fallbackTtsProvider:   config.fallback?.tts?.provider || '',
+      fallbackTtsModel:      config.fallback?.tts?.model || '',
+      fallbackTtsVoiceId:    config.fallback?.tts?.voiceId || '',
+      fallbackTtsVoiceConfig: config.fallback?.tts?.voiceConfig || {},
+
+      fallbackSttEnabled:    config.fallback?.stt?.enabled ?? false,
+      fallbackSttProvider:   config.fallback?.stt?.provider || '',
+      fallbackSttModel:      config.fallback?.stt?.model || '',
+      fallbackSttConfig:     config.fallback?.stt?.config || {},
     },
     ttsConfig: {
       provider: config.tts.provider,
@@ -294,6 +367,10 @@ export function deserializeConfig(json: string): DeserializedConfig {
     azureConfig: {
       endpoint:   config.llm.azureConfig?.endpoint   || '',
       apiVersion: config.llm.azureConfig?.apiVersion || '',
+    },
+    fallbackAzureConfig: {
+      endpoint:   config.fallback?.llm?.azureConfig?.endpoint   || '',
+      apiVersion: config.fallback?.llm?.azureConfig?.apiVersion || '',
     },
   }
 }
@@ -357,6 +434,10 @@ function deserializeFromSnapshot(parsed: any): DeserializedConfig {
     azureConfig: {
       endpoint:   a.llm?.azureConfig?.endpoint   || '',
       apiVersion: a.llm?.azureConfig?.apiVersion || '',
+    },
+    fallbackAzureConfig: {
+      endpoint:   a.llm?.fallback?.azure_endpoint || '',
+      apiVersion: a.llm?.fallback?.api_version    || '',
     },
   }
 }


### PR DESCRIPTION
## Summary

Adds UI support for configuring backup AI providers per modality in the LiveKit agent config dashboard. When a primary STT, TTS, or LLM provider fails during a live call, the agent automatically switches to the configured backup with no call drop.

- Toggle + provider selector for STT fallback, TTS fallback, and LLM fallback in `livekit/page.tsx`
- 9 new Formik fields in `useAgentConfig.ts` (`fallbackSttEnabled`, `fallbackTtsEnabled`, `fallbackLlmEnabled`, + provider/model/voice fields per modality)
- `buildSavePayload()` in `useMultiAssistantState.ts` conditionally injects `stt.fallback`, `tts.fallback`, `llm.fallback` into the API payload
- Hydration from saved config — existing agents without fallback load without any change
- 5 new handlers for fallback select/change events
