### PR TITLE
Fix: remove premature send from on_session_close to fix missing recor…

### DIFF
--- a/sdk/whispey/event_handlers.py
+++ b/sdk/whispey/event_handlers.py
@@ -322,6 +322,8 @@ class CorrectedTranscriptCollector:
                 if config:
                     self.current_turn.turn_configuration = config
 
+        if not hasattr(event.item, 'role'):
+            return
         if event.item.role == "user":
             original_text = event.item.text_content
             

--- a/sdk/whispey/whispey.py
+++ b/sdk/whispey/whispey.py
@@ -306,9 +306,8 @@ def observe_session(session, agent_id, host_url, room=None, bug_detector=None, e
                             await asyncio.sleep(10)
                             if (session_id in _session_data_store and
                                     _session_data_store[session_id].get('last_participant_disconnect') == disconnect_time):
-                                logger.info(f"👤 Participant left and didn't reconnect — sending transcript for {session_id}")
+                                logger.info(f"👤 Participant left and didn't reconnect — marking session ended (whispey_shutdown will export with recording URL)")
                                 end_session_manually(session_id, "completed")
-                                await send_session_to_whispey(session_id)
                         try:
                             loop = asyncio.get_running_loop()
                             loop.create_task(_send_after_participant_leave())
@@ -723,9 +722,14 @@ def end_session_manually(session_id: str, status: str = "completed", error: str 
     if session_id not in _session_data_store:
         logger.error(f"Session {session_id} not found for manual end")
         return
-    
+
+    # ponytail: already ended — don't overwrite cached transcript with 0 turns on a second call
+    if not _session_data_store[session_id].get('call_active', True):
+        logger.info(f"⏭️ Session {session_id} already ended, skipping re-generation")
+        return
+
     logger.info(f"🔚 Manually ending session {session_id} with status: {status}")
-    
+
     # Mark as inactive
     _session_data_store[session_id]['call_active'] = False
     

--- a/sdk/whispey/whispey.py
+++ b/sdk/whispey/whispey.py
@@ -331,12 +331,6 @@ def observe_session(session, agent_id, host_url, room=None, bug_detector=None, e
             def on_session_close(event):
                 error_msg = str(event.error) if hasattr(event, 'error') and event.error else None
                 end_session_manually(session_id, "completed", error_msg)
-                import asyncio
-                try:
-                    loop = asyncio.get_running_loop()
-                    loop.create_task(send_session_to_whispey(session_id))
-                except RuntimeError:
-                    asyncio.run(send_session_to_whispey(session_id))
         try:
             import asyncio
             def _on_done(task):

--- a/src/app/api/agents/[id]/history/route.ts
+++ b/src/app/api/agents/[id]/history/route.ts
@@ -143,8 +143,8 @@ export async function GET(
   try {
     const { id: agentId } = await params
     const { searchParams } = new URL(req.url)
-    const page = Math.max(1, parseInt(searchParams.get('page') || '1'))
-    const limit = Math.min(50, Math.max(1, parseInt(searchParams.get('limit') || '20')))
+    const page = Math.max(1, Number.parseInt(searchParams.get('page') || '1'))
+    const limit = Math.min(50, Math.max(1, Number.parseInt(searchParams.get('limit') || '20')))
     const offset = (page - 1) * limit
 
     const { data, error, count } = await supabase

--- a/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/ToolsActionsSettingsProps.tsx
+++ b/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/ToolsActionsSettingsProps.tsx
@@ -836,7 +836,7 @@ function ToolsActionsSettings({ tools, onFieldChange, projectId }: ToolsActionsS
                       min="0"
                       max="60"
                       value={formData.cooldown_seconds}
-                      onChange={(e) => setFormData(prev => ({ ...prev, cooldown_seconds: parseInt(e.target.value) || 3 }))}
+                      onChange={(e) => setFormData(prev => ({ ...prev, cooldown_seconds: Number.parseInt(e.target.value) || 3 }))}
                       className="h-7 text-xs mt-1 bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700"
                       placeholder="3"
                     />
@@ -1094,7 +1094,7 @@ function ToolsActionsSettings({ tools, onFieldChange, projectId }: ToolsActionsS
                       min="1"
                       max="120"
                       value={formData.timeout}
-                      onChange={(e) => setFormData(prev => ({ ...prev, timeout: parseInt(e.target.value) || 10 }))}
+                      onChange={(e) => setFormData(prev => ({ ...prev, timeout: Number.parseInt(e.target.value) || 10 }))}
                       className="h-7 text-xs mt-1 bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700"
                       placeholder="10"
                     />
@@ -1438,7 +1438,7 @@ function ToolsActionsSettings({ tools, onFieldChange, projectId }: ToolsActionsS
                       min="1"
                       max="20"
                       value={formData.max_results}
-                      onChange={(e) => setFormData(prev => ({ ...prev, max_results: parseInt(e.target.value) || 3 }))}
+                      onChange={(e) => setFormData(prev => ({ ...prev, max_results: Number.parseInt(e.target.value) || 3 }))}
                       className="h-7 text-xs mt-1 bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700"
                       placeholder="3"
                     />

--- a/src/components/projects/CallbackSettings.tsx
+++ b/src/components/projects/CallbackSettings.tsx
@@ -52,7 +52,7 @@ const DEFAULT_SETTINGS: CallbackSettingsData = {
 function formatTime12h(t: string): string {
   if (!t || !/^\d{2}:\d{2}$/.test(t)) return t
   const [hStr, m] = t.split(':')
-  const h = parseInt(hStr, 10)
+  const h = Number.parseInt(hStr, 10)
   const period = h >= 12 ? 'PM' : 'AM'
   const h12 = h % 12 === 0 ? 12 : h % 12
   return `${h12}:${m} ${period}`
@@ -60,7 +60,7 @@ function formatTime12h(t: string): string {
 
 function minutesFromTime(t: string): number {
   if (!t || !/^\d{2}:\d{2}$/.test(t)) return 0
-  const [h, m] = t.split(':').map((x) => parseInt(x, 10))
+  const [h, m] = t.split(':').map((x) => Number.parseInt(x, 10))
   return h * 60 + m
 }
 
@@ -412,7 +412,7 @@ export default function CallbackSettings({ agentId, projectId, agentRuntime, pip
               max={365}
               value={form.maxFutureDays}
               onChange={(e) =>
-                setForm((p) => ({ ...p, maxFutureDays: parseInt(e.target.value) || 7 }))
+                setForm((p) => ({ ...p, maxFutureDays: Number.parseInt(e.target.value) || 7 }))
               }
               className="text-sm"
             />
@@ -431,7 +431,7 @@ export default function CallbackSettings({ agentId, projectId, agentRuntime, pip
               max={20}
               value={form.maxCallbacksPerContact}
               onChange={(e) =>
-                setForm((p) => ({ ...p, maxCallbacksPerContact: parseInt(e.target.value) || 3 }))
+                setForm((p) => ({ ...p, maxCallbacksPerContact: Number.parseInt(e.target.value) || 3 }))
               }
               className="text-sm"
             />
@@ -448,7 +448,7 @@ export default function CallbackSettings({ agentId, projectId, agentRuntime, pip
               max={1440}
               value={form.minDelayMinutes}
               onChange={(e) =>
-                setForm((p) => ({ ...p, minDelayMinutes: parseInt(e.target.value) || 2 }))
+                setForm((p) => ({ ...p, minDelayMinutes: Number.parseInt(e.target.value) || 2 }))
               }
               className="text-sm"
             />
@@ -465,7 +465,7 @@ export default function CallbackSettings({ agentId, projectId, agentRuntime, pip
               max={1440}
               value={form.defaultDelayMinutes}
               onChange={(e) =>
-                setForm((p) => ({ ...p, defaultDelayMinutes: parseInt(e.target.value) || 30 }))
+                setForm((p) => ({ ...p, defaultDelayMinutes: Number.parseInt(e.target.value) || 30 }))
               }
               className="text-sm"
             />


### PR DESCRIPTION
## Summary
  - Remove `send_session_to_whispey()` from `on_session_close` — it was racing with `whispey_shutdown()` and deleting
  the session before the recording URL was available
  - Add `hasattr(event.item, 'role')` guard in `on_conversation_item_added` to prevent crash on AgentHandoff events

  ## Root Cause
  `on_session_close` fires immediately on user hangup, before egress finishes uploading to S3. The premature send (no
  recording URL) + `cleanup_session()` meant `whispey_shutdown()` arrived ~24s later with the recording URL but found
  "Session not found".

  ## Fix
  `on_session_close` now only calls `end_session_manually()` (caches state, no delete). `whispey_shutdown()` in
  entrypoint.py remains the sole exporter and runs after egress completes with the recording URL.
  EOF
  )"