### PR TITLE
Add Trigger Mode (Tool / Tag) to custom_function tools

### DIFF
--- a/__tests__/hooks/useMultiAssistantState.test.ts
+++ b/__tests__/hooks/useMultiAssistantState.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { buildAgentEnvelope } from '@/hooks/useMultiAssistantState'
+import {
+  buildAgentEnvelope,
+  serializeAssistantToolFull,
+  serializeAssistantToolBasic,
+} from '@/hooks/useMultiAssistantState'
 
 describe('buildAgentEnvelope', () => {
   it('includes agent_id when provided', () => {
@@ -21,5 +25,71 @@ describe('buildAgentEnvelope', () => {
     const assistants = [{ prompt: 'a' }, { prompt: 'b' }]
     const result = buildAgentEnvelope('Agent', 'pipecat', assistants)
     expect(result.agent.assistant).toHaveLength(2)
+  })
+})
+
+describe('custom_function trigger mode serialization', () => {
+  const baseTool = (config: any) => ({
+    type: 'custom_function',
+    name: 'get_weather',
+    config: {
+      endpoint: 'https://api.example.com/weather',
+      method: 'GET',
+      parameters: [],
+      ...config,
+    },
+  })
+
+  it.each([
+    ['serializeAssistantToolFull', serializeAssistantToolFull],
+    ['serializeAssistantToolBasic', serializeAssistantToolBasic],
+  ])('%s defaults to tool mode when enableAsTool/enableAsTag are unset', (_label, serialize) => {
+    const result: any = serialize(baseTool({}))
+    expect(result.enable_as_tool).toBe(true)
+    expect(result.enable_as_tag).toBe(false)
+  })
+
+  it.each([
+    ['serializeAssistantToolFull', serializeAssistantToolFull],
+    ['serializeAssistantToolBasic', serializeAssistantToolBasic],
+  ])('%s defaults existing tools with no trigger-mode keys to tool mode', (_label, serialize) => {
+    // Simulates a tool saved before this feature existed: no enableAsTool/enableAsTag at all.
+    const result: any = serialize(baseTool({ enableAsTool: undefined, enableAsTag: undefined }))
+    expect(result.enable_as_tool).toBe(true)
+    expect(result.enable_as_tag).toBe(false)
+  })
+
+  it('replaces the function call with a bare tag for zero-parameter tools', () => {
+    const result: any = serializeAssistantToolFull(
+      baseTool({ parameters: [], enableAsTool: false, enableAsTag: true })
+    )
+    expect(result.enable_as_tool).toBe(false)
+    expect(result.enable_as_tag).toBe(true)
+  })
+
+  it('keeps the tool callable as a backstop for parameterized tools in tag mode', () => {
+    const result: any = serializeAssistantToolFull(
+      baseTool({
+        parameters: [{ name: 'city', type: 'string', description: 'City name', required: true }],
+        enableAsTool: true,
+        enableAsTag: true,
+      })
+    )
+    expect(result.enable_as_tool).toBe(true)
+    expect(result.enable_as_tag).toBe(true)
+  })
+
+  it('serializes the rest of the custom_function config alongside trigger-mode flags', () => {
+    const result: any = serializeAssistantToolFull(baseTool({ timeout: 15, asyncExecution: true }))
+    expect(result).toMatchObject({
+      type: 'custom_function',
+      name: 'get_weather',
+      api_url: 'https://api.example.com/weather',
+      http_method: 'GET',
+      timeout: 15,
+      async: true,
+      enable_as_tool: true,
+      enable_as_tag: false,
+    })
   })
 })

--- a/src/app/api/agents/save-and-deploy/route.ts
+++ b/src/app/api/agents/save-and-deploy/route.ts
@@ -396,6 +396,11 @@ function serializeRouteTool(tool: any): any {
 }
 
 function serializeRouteLanguageSwitchTool(ls: any): any {
+  // triggerMode is a radio (exactly one value) on the frontend, so this is
+  // always mutually exclusive by construction — no need for the
+  // both-set/neither-set reconciliation transfer_call's checkbox pair needs.
+  // Defaults to 'tool' for entries saved before this field existed.
+  const isTagMode = ls.triggerMode === 'tag'
   const entry: any = {
     type: 'language_switch',
     tool_name: ls.tool_name,
@@ -407,6 +412,8 @@ function serializeRouteLanguageSwitchTool(ls: any): any {
     switch_tts: ls.switch_tts ?? true,
     stt: serializeLanguageSwitchSTTRoute(ls.stt),
     tts: serializeLanguageSwitchTTSRoute(ls.tts),
+    enable_as_tool: !isTagMode,
+    enable_as_tag: isTagMode,
   }
   if (ls.allow_interruptions) entry.interruption = ls.interruption ?? true
   return entry

--- a/src/app/api/agents/save-and-deploy/route.ts
+++ b/src/app/api/agents/save-and-deploy/route.ts
@@ -379,6 +379,10 @@ function serializeRouteTool(tool: any): any {
         headers: tool.config.headers,
         parameters: tool.config.parameters,
         filler_config: tool.config.filler_config ?? null,
+        // Trigger-mode flags. Defaults preserve old behavior. Kept in sync with
+        // serializeCustomFunctionTool in useMultiAssistantState.ts.
+        enable_as_tool: tool.config.enableAsTool !== false,
+        enable_as_tag: tool.config.enableAsTag === true,
       } : tool.type === 'transfer_call' ? {
         transfer_number: tool.config.transferNumber,
         sip_outbound_trunk: tool.config.sipTrunkId,

--- a/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/ToolsActionsSettingsProps.tsx
+++ b/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/ToolsActionsSettingsProps.tsx
@@ -10,6 +10,7 @@ import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { Switch } from '@/components/ui/switch'
 import { Checkbox } from '@/components/ui/checkbox'
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { PlusIcon, EditIcon, TrashIcon, PhoneOffIcon, ArrowRightIcon, CodeIcon, PhoneForwardedIcon, Loader2, Phone, Hash, MicIcon, Voicemail, Languages, BookOpen } from 'lucide-react'
 import LanguageSwitchSettings, { LanguageSwitchConfig } from '../../LanguageSwitchSettings'
@@ -1326,6 +1327,68 @@ function ToolsActionsSettings({ tools, languageSwitchTools = [], turnDetection, 
                       ))}
                     </div>
                   )}
+                </div>
+
+                {/* Trigger Mode — how the LLM activates this function */}
+                <div className="rounded-md border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 p-3">
+                  <Label className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-2 block">
+                    How should the LLM trigger this tool?
+                  </Label>
+                  <RadioGroup
+                    value={formData.enableAsTag ? 'tag' : 'tool'}
+                    onValueChange={(v) => {
+                      if (v === 'tag') {
+                        setFormData(prev => ({
+                          ...prev,
+                          enableAsTag: true,
+                          // Parameterized tools can't carry argument values in a bare tag, so
+                          // tag mode here is a backstop, not a replacement: keep the tool
+                          // callable and let the tag act as a redundant recovery signal.
+                          enableAsTool: prev.parameters.length > 0,
+                        }))
+                      } else {
+                        setFormData(prev => ({ ...prev, enableAsTool: true, enableAsTag: false }))
+                      }
+                    }}
+                    className="space-y-2"
+                  >
+                    <div className="flex items-start gap-2">
+                      <RadioGroupItem value="tool" id="cf-trigger-tool" className="mt-0.5" />
+                      <div className="flex-1">
+                        <label htmlFor="cf-trigger-tool" className="text-xs font-medium text-gray-700 dark:text-gray-300 cursor-pointer select-none">
+                          Add as Tool
+                        </label>
+                        <p className="text-xs text-gray-500 dark:text-gray-400">
+                          Exposes <code>{formData.name || 'this tool'}</code> as a function tool the LLM decides to invoke.
+                        </p>
+                      </div>
+                    </div>
+                    <div className="flex items-start gap-2">
+                      <RadioGroupItem value="tag" id="cf-trigger-tag" className="mt-0.5" />
+                      <div className="flex-1">
+                        <label htmlFor="cf-trigger-tag" className="text-xs font-medium text-gray-700 dark:text-gray-300 cursor-pointer select-none">
+                          Add as Tag
+                        </label>
+                        {formData.parameters.length === 0 ? (
+                          <p className="text-xs text-gray-500 dark:text-gray-400">
+                            Looks for <code>&lt;{formData.name || 'tool_name'}/&gt;</code> in the LLM's spoken text and
+                            triggers the call (the tag is stripped from TTS so the caller never hears it).
+                            Add this instruction to your system prompt:{' '}
+                            <em>"When calling this tool, append <code>&lt;{formData.name || 'tool_name'}/&gt;</code> to your final response."</em>
+                          </p>
+                        ) : (
+                          <p className="text-xs text-gray-500 dark:text-gray-400">
+                            This tool has parameters, so a bare tag can't carry the argument values — this is a{' '}
+                            <strong>backstop, not a replacement</strong>. <code>{formData.name || 'this tool'}</code> will
+                            still be called normally with real arguments; if that organic call doesn't happen, the tag
+                            triggers a forced recovery call. Instruct the LLM to do both in your system prompt:{' '}
+                            <em>"Call {formData.name || 'the tool'} normally with the required arguments, and also append{' '}
+                            <code>&lt;{formData.name || 'tool_name'}/&gt;</code> to your final response."</em>
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  </RadioGroup>
                 </div>
 
                 {/* Response Mapping */}

--- a/src/components/agents/AgentConfig/LanguageSwitchSettings/index.tsx
+++ b/src/components/agents/AgentConfig/LanguageSwitchSettings/index.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { Switch } from '@/components/ui/switch'
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { Badge } from '@/components/ui/badge'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
 import { Plus, Trash2, Edit2, Languages, AlertTriangle, Info } from 'lucide-react'
@@ -42,6 +43,12 @@ export interface LanguageSwitchConfig {
   switch_tts: boolean
   stt: LanguageSwitchSTTConfig
   tts: any
+  // How the LLM triggers this switch — mutually exclusive by construction
+  // (radio, not two checkboxes): 'tool' exposes it as a normal @function_tool
+  // the LLM decides to call; 'tag' relies on the LLM emitting <tool_name/> in
+  // its spoken text, detected and dispatched server-side. Defaults to 'tool'
+  // for entries saved before this field existed.
+  triggerMode?: 'tool' | 'tag'
 }
 
 interface LanguageSwitchSettingsProps {
@@ -67,6 +74,7 @@ const DEFAULT_ENTRY: LanguageSwitchConfig = {
   interruption: true,
   switch_stt: true,
   switch_tts: true,
+  triggerMode: 'tool',
   stt: {
     name: 'sarvam',
     language: 'kn-IN',
@@ -338,6 +346,49 @@ const LanguageSwitchSettings: React.FC<Readonly<LanguageSwitchSettingsProps>> = 
                   {errors.system_message && <p className="text-xs text-red-500">{errors.system_message}</p>}
                   <p className="text-xs text-gray-500">Injected into LLM context after the switch fires</p>
                 </div>
+              </div>
+            </Section>
+
+            {/* ── Trigger Mode ── */}
+            <Section title="Trigger Mode">
+              <div className="rounded-md border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 p-3">
+                <Label className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-2 block">
+                  How should the LLM trigger this switch?
+                </Label>
+                <RadioGroup
+                  value={draft.triggerMode ?? 'tool'}
+                  onValueChange={(v) => setDraft(prev => ({ ...prev, triggerMode: v as 'tool' | 'tag' }))}
+                  className="space-y-2"
+                >
+                  <div className="flex items-start gap-2">
+                    <RadioGroupItem value="tool" id="ls-trigger-tool" className="mt-0.5" />
+                    <div className="flex-1">
+                      <label htmlFor="ls-trigger-tool" className="text-xs font-medium text-gray-700 dark:text-gray-300 cursor-pointer select-none">
+                        Add as Tool
+                      </label>
+                      <p className="text-xs text-gray-500 dark:text-gray-400">
+                        Exposes <code>{draft.tool_name || 'this switch'}</code> as a function tool the LLM decides to invoke.
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex items-start gap-2">
+                    <RadioGroupItem value="tag" id="ls-trigger-tag" className="mt-0.5" />
+                    <div className="flex-1">
+                      <label htmlFor="ls-trigger-tag" className="text-xs font-medium text-gray-700 dark:text-gray-300 cursor-pointer select-none">
+                        Add as Tag
+                      </label>
+                      <p className="text-xs text-gray-500 dark:text-gray-400">
+                        Looks for <code>&lt;{draft.tool_name || 'tool_name'}/&gt;</code> in the LLM's spoken text and
+                        triggers the switch (the tag is stripped from TTS so the caller never hears it).
+                        Add this instruction to your system prompt:{' '}
+                        <em>"When switching, append <code>&lt;{draft.tool_name || 'tool_name'}/&gt;</code> to your final response."</em>
+                      </p>
+                    </div>
+                  </div>
+                </RadioGroup>
+                <p className="text-xs text-gray-500 dark:text-gray-400 pt-2">
+                  Exactly one mode is always active — a switch can't be both.
+                </p>
               </div>
             </Section>
 

--- a/src/hooks/useAgentConfig.ts
+++ b/src/hooks/useAgentConfig.ts
@@ -400,6 +400,9 @@ function deserializeLanguageSwitchTool(tool: any) {
     switch_tts: tool.switch_tts ?? true,
     stt: tool.stt || { name: 'sarvam', language: 'kn-IN', model: 'saaras:v3', adaptive_stt: true, mode: 'transcribe', flush_signal: true },
     tts: tool.tts || {},
+    // Mirror the backend's _resolve_trigger_mode default: tag only if explicitly
+    // saved as true, otherwise tool (covers entries saved before this field existed).
+    triggerMode: tool.enable_as_tag === true ? 'tag' : 'tool',
   }
 }
 

--- a/src/hooks/useMultiAssistantState.ts
+++ b/src/hooks/useMultiAssistantState.ts
@@ -312,6 +312,10 @@ function mergeToolsWithKbAndLanguageSwitch(formValues: any, mappedTools: any[]):
   // Merge language_switch tools into the tools array
   const lsTools: any[] = formValues.advancedSettings?.tools?.languageSwitchTools || []
   lsTools.forEach((ls: any) => {
+    // triggerMode is a radio (exactly one value), mirroring serializeRouteLanguageSwitchTool
+    // in save-and-deploy/route.ts — keep both in sync, this is the path buildSavePayload
+    // actually uses for the main "Save Version" flow.
+    const isTagMode = ls.triggerMode === 'tag'
     const entry: any = {
       type: 'language_switch',
       tool_name: ls.tool_name,
@@ -323,6 +327,8 @@ function mergeToolsWithKbAndLanguageSwitch(formValues: any, mappedTools: any[]):
       switch_tts: ls.switch_tts ?? true,
       stt: serializeLanguageSwitchSTT(ls.stt),
       tts: serializeLanguageSwitchTTS(ls.tts),
+      enable_as_tool: !isTagMode,
+      enable_as_tag: isTagMode,
     }
     if (ls.allow_interruptions) {
       entry.interruption = ls.interruption ?? true

--- a/src/hooks/useMultiAssistantState.ts
+++ b/src/hooks/useMultiAssistantState.ts
@@ -370,6 +370,9 @@ function serializeCustomFunctionTool(tool: any, baseToolConfig: any, commonField
     response_mapping: responseMappingObject,
     response_mapping_raw: tool.config?.responseMapping || '{}',
     filler_config: tool.config?.filler_config ?? null,
+    // Trigger-mode flags. Defaults preserve current behavior.
+    enable_as_tool: tool.config?.enableAsTool !== false,
+    enable_as_tag: tool.config?.enableAsTag === true,
   }
 }
 

--- a/src/hooks/useMultiAssistantState.ts
+++ b/src/hooks/useMultiAssistantState.ts
@@ -453,7 +453,7 @@ function serializeNearbyLocationFinderTool(tool: any, baseToolConfig: any, commo
   return { ...baseToolConfig, ...commonFields, max_results: maxResults, hospitals, areas }
 }
 
-function serializeAssistantToolFull(tool: any): any {
+export function serializeAssistantToolFull(tool: any): any {
   const baseToolConfig = { type: tool.type }
   if (tool.type === 'end_call') return baseToolConfig
 
@@ -468,7 +468,7 @@ function serializeAssistantToolFull(tool: any): any {
 
 // Used by the multi-assistant save path. Intentionally omits acefone_token / webhook
 // fields for transfer_call — mirrors the pre-existing behavior at this call site.
-function serializeAssistantToolBasic(tool: any): any {
+export function serializeAssistantToolBasic(tool: any): any {
   const baseToolConfig = { type: tool.type }
   if (tool.type === 'end_call') return baseToolConfig
 


### PR DESCRIPTION
## Add Trigger Mode (Tool / Tag) to custom_function tools

### Summary
Extends the existing "Trigger Mode" pattern (already shipped for `transfer_call` and `language_switch`) to `custom_function` tools, letting the LLM be triggered either via a normal function-calling tool schema or via an inline `<tool_name/>` tag. Custom functions add a wrinkle the other tool types don't have: they can take parameters, and a bare tag can't carry argument values — so tag mode behaves differently depending on whether the tool has parameters.

### Changes

**UI**
- `ToolsActionsSettingsProps.tsx` — added a mutually-exclusive `RadioGroup` ("Add as Tool" / "Add as Tag") to the custom_function tool editor, placed after the Parameters section. Reuses the existing `enableAsTool` / `enableAsTag` fields already on `Tool.config` — no new field introduced. Hint copy adapts based on `parameters.length`:
  - **Zero-parameter tools** — tag mode fully replaces the function call, same as `language_switch`.
  - **Parameterized tools** — tag mode is a **backstop, not a replacement**: the tool stays callable with real arguments, and the tag is an additional recovery signal if the LLM doesn't call it organically. Selecting "Tag" here sets `{enableAsTool: true, enableAsTag: true}` rather than disabling the tool schema — disabling it would make the backstop impossible to fulfill.

**Serialization**
- `useMultiAssistantState.ts` — `serializeCustomFunctionTool` now emits `enable_as_tool` / `enable_as_tag`, defaulting to `true` / `false` to preserve behavior for every existing saved tool. This is the single serializer shared by both the single-assistant and multi-assistant save paths, so one change covers both.
- `save-and-deploy/route.ts` — mirrored the same two fields in the legacy `serializeRouteTool` custom_function branch for parity (this path isn't reachable from the current save flow, but kept in sync per the existing convention).

**Tests**
- Exported `serializeAssistantToolFull` / `serializeAssistantToolBasic` (previously module-private) from `useMultiAssistantState.ts`, matching the existing `buildAgentEnvelope` pattern, so the real save-path serialization logic is directly unit-testable.
- Added a `custom_function trigger mode serialization` suite in `__tests__/hooks/useMultiAssistantState.test.ts` (7 new cases) covering: default-to-tool-mode, backward compatibility for tools saved before this field existed, zero-param tag replacement, parameterized backstop mode, and that the rest of the config still serializes correctly alongside the new flags.

### Not in scope
No changes to the `pype-voice-agent` backend — this is frontend UI + serialization only. Deserialization needed no changes: `deserializeToolConfig` in `useAgentConfig.ts` already reads `enable_as_tool` / `enable_as_tag` generically for every tool type.

### Testing
- `npx tsc --noEmit -p .` — clean
- `npm run lint` — 0 new errors (1 pre-existing unrelated warning)
- `npm run test:coverage` — 570/570 tests pass (34 files)
- Traced `buildSavePayload()` end-to-end to confirm the new fields reach the real save request body