### PR TITLE
feat: add config diff checker with UI and tests

### DIFF
--- a/__tests__/lib/configDiff.test.ts
+++ b/__tests__/lib/configDiff.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest'
+import { buildSideBySideRows, hasChanges, sanitizeForDiff, serializeForDiff, extractPrompt, omitPrompt } from '@/lib/configDiff'
+
+describe('buildSideBySideRows', () => {
+  it('marks identical text as fully unchanged with no changed rows', () => {
+    const rows = buildSideBySideRows('a\nb\nc', 'a\nb\nc')
+    expect(hasChanges(rows)).toBe(false)
+  })
+
+  it('pairs a single changed line row-for-row', () => {
+    const rows = buildSideBySideRows('a\nb\nc', 'a\nB\nc')
+    const changed = rows.filter(r => r.type === 'changed') as any[]
+    expect(changed).toHaveLength(1)
+    expect(changed[0].left.content).toBe('b')
+    expect(changed[0].right.content).toBe('B')
+  })
+
+  it('collapses unchanged runs beyond the context window', () => {
+    const oldLines = Array.from({ length: 20 }, (_, i) => `line${i}`).join('\n')
+    const newLines = oldLines.replace('line10', 'CHANGED')
+    const rows = buildSideBySideRows(oldLines, newLines, 2)
+    expect(rows.some(r => r.type === 'collapsed')).toBe(true)
+    const collapsed = rows.filter(r => r.type === 'collapsed') as any[]
+    const collapsedLineCount = collapsed.reduce((sum, g) => sum + g.rows.length, 0)
+    // 20 unchanged lines minus the 1 changed line minus 2*context kept around it
+    expect(collapsedLineCount).toBe(20 - 1 - 4)
+  })
+
+  it('does not collapse anything shorter than the context window', () => {
+    const rows = buildSideBySideRows('a\nb\nc', 'a\nB\nc', 2)
+    expect(rows.some(r => r.type === 'collapsed')).toBe(false)
+  })
+
+  it('pads mismatched add/remove block lengths with nulls', () => {
+    const rows = buildSideBySideRows('a\nb\nc', 'a\nX\nY\nZ\nc')
+    const changed = rows.filter(r => r.type === 'changed') as any[]
+    expect(changed).toHaveLength(3)
+    expect(changed[0].left?.content).toBe('b')
+    expect(changed[1].left).toBeNull()
+    expect(changed[2].left).toBeNull()
+    expect(changed.map(c => c.right.content)).toEqual(['X', 'Y', 'Z'])
+  })
+})
+
+describe('sanitizeForDiff', () => {
+  it('strips secret fields that always differ between snapshots', () => {
+    const clean = sanitizeForDiff({ agent: { whispey_api_key: 'x', token_hash: 'y', name: 'foo' } })
+    expect(clean.agent.whispey_api_key).toBeUndefined()
+    expect(clean.agent.token_hash).toBeUndefined()
+    expect(clean.agent.name).toBe('foo')
+  })
+
+  it('does not mutate the input object', () => {
+    const original = { agent: { whispey_api_key: 'x' } }
+    sanitizeForDiff(original)
+    expect(original.agent.whispey_api_key).toBe('x')
+  })
+
+  it('produces identical output for objects that differ only in key order', () => {
+    const a = { agent: { b: 1, a: 2, nested: { y: 1, x: 2 } } }
+    const b = { agent: { a: 2, b: 1, nested: { x: 2, y: 1 } } }
+    expect(JSON.stringify(sanitizeForDiff(a))).toBe(JSON.stringify(sanitizeForDiff(b)))
+  })
+
+  it('preserves array element order', () => {
+    const clean = sanitizeForDiff({ agent: { tools: ['b', 'a'] } })
+    expect(clean.agent.tools).toEqual(['b', 'a'])
+  })
+})
+
+describe('extractPrompt / omitPrompt', () => {
+  const config = { agent: { assistant: [{ prompt: 'hello', name: 'bot' }] } }
+
+  it('extracts the prompt text from the assistant snapshot', () => {
+    expect(extractPrompt(config)).toBe('hello')
+  })
+
+  it('returns empty string when there is no prompt', () => {
+    expect(extractPrompt({})).toBe('')
+  })
+
+  it('strips the prompt but keeps everything else', () => {
+    const rest = omitPrompt(config)
+    expect(rest.agent.assistant[0].prompt).toBeUndefined()
+    expect(rest.agent.assistant[0].name).toBe('bot')
+  })
+
+  it('does not mutate the input', () => {
+    omitPrompt(config)
+    expect(config.agent.assistant[0].prompt).toBe('hello')
+  })
+})
+
+describe('serializeForDiff', () => {
+  it('expands embedded newlines into real line breaks', () => {
+    const text = serializeForDiff({ prompt: 'line one\nline two\nline three' })
+    expect(text.split('\n').length).toBeGreaterThan(1)
+    expect(text).toContain('line one')
+    expect(text).toContain('line two')
+  })
+
+  it('isolates a small edit inside a multi-line string to one changed line', () => {
+    const before = serializeForDiff({ prompt: 'alpha\nbeta\ngamma' })
+    const after = serializeForDiff({ prompt: 'alpha\nBETA\ngamma' })
+    const rows = buildSideBySideRows(before, after, 0)
+    const changed = rows.filter(r => r.type === 'changed') as any[]
+    expect(changed).toHaveLength(1)
+    expect(changed[0].left.content.trim()).toBe('beta')
+    expect(changed[0].right.content.trim()).toBe('BETA')
+  })
+})

--- a/src/app/[projectid]/agents/[agentid]/config/livekit/page.tsx
+++ b/src/app/[projectid]/agents/[agentid]/config/livekit/page.tsx
@@ -38,6 +38,8 @@ import {
 import { firstMessageModes } from '@/utils/constants'
 import { useFormik } from 'formik'
 import ModelSelector from '@/components/agents/AgentConfig/ModelSelector'
+import { SideBySideDiff } from '@/components/agents/AgentConfig/SideBySideDiff'
+import { sanitizeForDiff, serializeForDiff, extractPrompt, omitPrompt } from '@/lib/configDiff'
 import SelectTTS from '@/components/agents/AgentConfig/SelectTTSDialog'
 import SelectSTT from '@/components/agents/AgentConfig/SelectSTTDialog'
 import AgentAdvancedSettings from '@/components/agents/AgentConfig/AgentAdvancedSettings'
@@ -245,6 +247,10 @@ export default function AgentConfig() {
   const [isSavingVersion, setIsSavingVersion] = useState(false)
   const [versionSaveError, setVersionSaveError] = useState<string | null>(null)
   const [showMergePrompt, setShowMergePrompt] = useState(false)
+  const [publishedSnapshot, setPublishedSnapshot] = useState<any>(null)
+  const [isDiffLoading, setIsDiffLoading] = useState(false)
+  const promptDiffRef = useRef<HTMLDivElement>(null)
+  const settingsDiffRef = useRef<HTMLDivElement>(null)
 
   const [flashEndCall, setFlashEndCall] = useState(false)
   const isTalkToAssistantSessionActiveRef = useRef(false)
@@ -482,11 +488,19 @@ export default function AgentConfig() {
     }
   })
 
-  // Webhook/dropoff/callback config load asynchronously (separate API calls) after the
-  // form is already initialized. Rebase both values AND the dirty-check baseline here so
-  // loading a section's saved config doesn't itself mark the form dirty, and so Discard
-  // reverts to the real loaded config instead of wiping it back to undefined.
+  // Webhook/dropoff/callback settings sections are collapsible and only fetch their own
+  // saved config the first time they're expanded — which can happen *after* a paste has
+  // already set these fields. Without a guard, that late fetch overwrites pasted values
+  // with the target agent's own stale saved settings. First load per field wins; a paste
+  // also counts as establishing the field so a later section-expand can't clobber it.
+  const supplementalEstablishedRef = useRef<Set<string>>(new Set())
+  useEffect(() => {
+    supplementalEstablishedRef.current.clear()
+  }, [agentid])
+
   const loadSupplementalSetting = (field: 'webhook' | 'dropoff' | 'callbackScheduling', data: any) => {
+    if (supplementalEstablishedRef.current.has(field)) return
+    supplementalEstablishedRef.current.add(field)
     formik.resetForm({
       values: {
         ...formik.values,
@@ -590,6 +604,14 @@ export default function AgentConfig() {
     // Apply formik values
     formik.setValues(config.formikValues, false) // false = don't validate immediately
 
+    // If the pasted config specifies webhook/dropoff/callback settings, lock them in as
+    // established so a section expanded later (which fetches its own saved settings on
+    // first mount) doesn't overwrite the pasted values with the target agent's old ones.
+    const pastedAdvanced = config.formikValues.advancedSettings as any
+    for (const field of ['webhook', 'dropoff', 'callbackScheduling'] as const) {
+      if (pastedAdvanced?.[field] !== undefined) supplementalEstablishedRef.current.add(field)
+    }
+
     // Apply external state
     setTtsConfig(config.ttsConfig)
     setSTTConfig(config.sttConfig)
@@ -637,7 +659,20 @@ export default function AgentConfig() {
     setPendingCheckpoint({ config: payload, userEmail, userId })
     setCommitMessage('')
     setVersionSaveError(null)
+    setPublishedSnapshot(null)
     setIsCommitModalOpen(true)
+
+    setIsDiffLoading(true)
+    fetch(`/api/agents/${agentid}/history?page=1&limit=1`)
+      .then(res => (res.ok ? res.json() : null))
+      .then(data => {
+        const latest = data?.history?.[0]
+        if (!latest?.id) return null
+        return fetch(`/api/agents/${agentid}/history/${latest.id}`).then(r => (r.ok ? r.json() : null))
+      })
+      .then(detail => setPublishedSnapshot(detail?.entry?.config_snapshot ?? null))
+      .catch(() => setPublishedSnapshot(null))
+      .finally(() => setIsDiffLoading(false))
   }
 
   const handleSaveVersion = async () => {
@@ -1702,26 +1737,89 @@ const unmappedVariablesCount = useMemo(() => {
         agentEnvironment={agentDataResponse?.[0]?.environment ?? 'dev'}
       />
 
-      {/* Commit message dialog */}
+      {/* Review changes / commit dialog */}
       <Dialog open={isCommitModalOpen} onOpenChange={v => { if (!v && !isSavingVersion) setIsCommitModalOpen(false) }}>
-        <DialogContent className="sm:max-w-md">
+        <DialogContent className="sm:max-w-5xl max-w-[calc(100%-2rem)] max-h-[90vh] overflow-y-auto">
           <DialogHeader>
-            <DialogTitle className="text-sm font-semibold">Save prompt version</DialogTitle>
+            <DialogTitle className="text-sm font-semibold">Review Changes</DialogTitle>
           </DialogHeader>
+          <p className="px-3 py-1.5 text-[11px] font-medium text-amber-600 bg-amber-500/15 rounded-md">
+            Seeing changes you didn't make? Refresh the page and try again.
+          </p>
           <div className="space-y-3 py-2">
             <div className="space-y-1.5">
-              <label className="text-xs font-medium text-foreground">Describe this change</label>
+              <label className="text-xs font-medium text-foreground">Commit message</label>
               <Textarea
                 placeholder="e.g. Fixed greeting for missed calls"
                 value={commitMessage}
                 onChange={e => setCommitMessage(e.target.value)}
                 className="text-sm resize-none"
-                rows={3}
+                rows={2}
                 autoFocus
                 onKeyDown={e => { if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) handleSaveVersion() }}
               />
-              <p className="text-[11px] text-muted-foreground">Press ⌘↵ to save quickly.</p>
+              <p className="text-[11px] text-muted-foreground">Press ⌘↵ to publish quickly.</p>
             </div>
+
+            {isDiffLoading ? (
+              <div className="flex items-center justify-center py-6 text-xs text-muted-foreground gap-2">
+                <Loader2 className="w-3.5 h-3.5 animate-spin" /> Loading diff...
+              </div>
+            ) : pendingCheckpoint ? (() => {
+                const publishedFull = publishedSnapshot ? sanitizeForDiff(publishedSnapshot) : {}
+                const currentFull = sanitizeForDiff(pendingCheckpoint.config)
+                const publishedSettings = {
+                  ...omitPrompt(publishedFull),
+                  webhook: (formik.initialValues.advancedSettings as any)?.webhook ?? null,
+                  dropoff: (formik.initialValues.advancedSettings as any)?.dropoff ?? null,
+                  callbackScheduling: (formik.initialValues.advancedSettings as any)?.callbackScheduling ?? null,
+                }
+                const currentSettings = {
+                  ...omitPrompt(currentFull),
+                  webhook: (formik.values.advancedSettings as any)?.webhook ?? null,
+                  dropoff: (formik.values.advancedSettings as any)?.dropoff ?? null,
+                  callbackScheduling: (formik.values.advancedSettings as any)?.callbackScheduling ?? null,
+                }
+                return (
+                  <div className="space-y-3">
+                    <div className="flex gap-2 sticky top-0 z-10 bg-background pb-1">
+                      <Button
+                        type="button" variant="outline" size="sm" className="h-7 text-xs"
+                        onClick={() => promptDiffRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })}
+                      >
+                        Prompt
+                      </Button>
+                      <Button
+                        type="button" variant="outline" size="sm" className="h-7 text-xs"
+                        onClick={() => settingsDiffRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })}
+                      >
+                        Settings
+                      </Button>
+                    </div>
+
+                    <div ref={promptDiffRef}>
+                      <p className="text-[11px] font-medium text-muted-foreground mb-1">Prompt</p>
+                      <SideBySideDiff
+                        oldText={extractPrompt(publishedFull)}
+                        newText={extractPrompt(currentFull)}
+                      />
+                    </div>
+
+                    <div ref={settingsDiffRef}>
+                      <p className="text-[11px] font-medium text-muted-foreground mb-1">Settings</p>
+                      <SideBySideDiff
+                        oldText={serializeForDiff(publishedSettings)}
+                        newText={serializeForDiff(currentSettings)}
+                      />
+                    </div>
+                  </div>
+                )
+              })() : null}
+
+            {!isDiffLoading && !publishedSnapshot && (
+              <p className="text-[11px] text-muted-foreground">No prior published version — this will be the first version.</p>
+            )}
+
             {versionSaveError && <p className="text-xs text-destructive">{versionSaveError}</p>}
           </div>
           <div className="flex justify-end gap-2 pt-1">
@@ -1738,8 +1836,8 @@ const unmappedVariablesCount = useMemo(() => {
               disabled={isSavingVersion || !commitMessage.trim()}
             >
               {isSavingVersion
-                ? <><Loader2 className="w-3 h-3 mr-1 animate-spin" />Saving...</>
-                : 'Save & Deploy'
+                ? <><Loader2 className="w-3 h-3 mr-1 animate-spin" />Publishing...</>
+                : 'Publish'
               }
             </Button>
           </div>

--- a/src/app/[projectid]/agents/[agentid]/config/livekit/page.tsx
+++ b/src/app/[projectid]/agents/[agentid]/config/livekit/page.tsx
@@ -607,7 +607,7 @@ export default function AgentConfig() {
     // If the pasted config specifies webhook/dropoff/callback settings, lock them in as
     // established so a section expanded later (which fetches its own saved settings on
     // first mount) doesn't overwrite the pasted values with the target agent's old ones.
-    const pastedAdvanced = config.formikValues.advancedSettings as any
+    const pastedAdvanced = config.formikValues.advancedSettings
     for (const field of ['webhook', 'dropoff', 'callbackScheduling'] as const) {
       if (pastedAdvanced?.[field] !== undefined) supplementalEstablishedRef.current.add(field)
     }
@@ -722,6 +722,69 @@ export default function AgentConfig() {
     } finally {
       setIsSavingVersion(false)
     }
+  }
+
+  const renderDiffContent = () => {
+    if (isDiffLoading) {
+      return (
+        <div className="flex items-center justify-center py-6 text-xs text-muted-foreground gap-2">
+          <Loader2 className="w-3.5 h-3.5 animate-spin" /> Loading diff...
+        </div>
+      )
+    }
+    if (!pendingCheckpoint) return null
+
+    const publishedFull = publishedSnapshot ? sanitizeForDiff(publishedSnapshot) : {}
+    const currentFull = sanitizeForDiff(pendingCheckpoint.config)
+    const publishedAdvanced = formik.initialValues.advancedSettings as any
+    const currentAdvanced = formik.values.advancedSettings as any
+    const publishedSettings = {
+      ...omitPrompt(publishedFull),
+      webhook: publishedAdvanced?.webhook ?? null,
+      dropoff: publishedAdvanced?.dropoff ?? null,
+      callbackScheduling: publishedAdvanced?.callbackScheduling ?? null,
+    }
+    const currentSettings = {
+      ...omitPrompt(currentFull),
+      webhook: currentAdvanced?.webhook ?? null,
+      dropoff: currentAdvanced?.dropoff ?? null,
+      callbackScheduling: currentAdvanced?.callbackScheduling ?? null,
+    }
+
+    return (
+      <div className="space-y-3">
+        <div className="flex gap-2 sticky top-0 z-10 bg-background pb-1">
+          <Button
+            type="button" variant="outline" size="sm" className="h-7 text-xs"
+            onClick={() => promptDiffRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })}
+          >
+            Prompt
+          </Button>
+          <Button
+            type="button" variant="outline" size="sm" className="h-7 text-xs"
+            onClick={() => settingsDiffRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })}
+          >
+            Settings
+          </Button>
+        </div>
+
+        <div ref={promptDiffRef}>
+          <p className="text-[11px] font-medium text-muted-foreground mb-1">Prompt</p>
+          <SideBySideDiff
+            oldText={extractPrompt(publishedFull)}
+            newText={extractPrompt(currentFull)}
+          />
+        </div>
+
+        <div ref={settingsDiffRef}>
+          <p className="text-[11px] font-medium text-muted-foreground mb-1">Settings</p>
+          <SideBySideDiff
+            oldText={serializeForDiff(publishedSettings)}
+            newText={serializeForDiff(currentSettings)}
+          />
+        </div>
+      </div>
+    )
   }
 
   const handleCancel = () => {
@@ -1748,8 +1811,9 @@ const unmappedVariablesCount = useMemo(() => {
           </p>
           <div className="space-y-3 py-2">
             <div className="space-y-1.5">
-              <label className="text-xs font-medium text-foreground">Commit message</label>
+              <label htmlFor="commit-message" className="text-xs font-medium text-foreground">Commit message</label>
               <Textarea
+                id="commit-message"
                 placeholder="e.g. Fixed greeting for missed calls"
                 value={commitMessage}
                 onChange={e => setCommitMessage(e.target.value)}
@@ -1761,60 +1825,7 @@ const unmappedVariablesCount = useMemo(() => {
               <p className="text-[11px] text-muted-foreground">Press ⌘↵ to publish quickly.</p>
             </div>
 
-            {isDiffLoading ? (
-              <div className="flex items-center justify-center py-6 text-xs text-muted-foreground gap-2">
-                <Loader2 className="w-3.5 h-3.5 animate-spin" /> Loading diff...
-              </div>
-            ) : pendingCheckpoint ? (() => {
-                const publishedFull = publishedSnapshot ? sanitizeForDiff(publishedSnapshot) : {}
-                const currentFull = sanitizeForDiff(pendingCheckpoint.config)
-                const publishedSettings = {
-                  ...omitPrompt(publishedFull),
-                  webhook: (formik.initialValues.advancedSettings as any)?.webhook ?? null,
-                  dropoff: (formik.initialValues.advancedSettings as any)?.dropoff ?? null,
-                  callbackScheduling: (formik.initialValues.advancedSettings as any)?.callbackScheduling ?? null,
-                }
-                const currentSettings = {
-                  ...omitPrompt(currentFull),
-                  webhook: (formik.values.advancedSettings as any)?.webhook ?? null,
-                  dropoff: (formik.values.advancedSettings as any)?.dropoff ?? null,
-                  callbackScheduling: (formik.values.advancedSettings as any)?.callbackScheduling ?? null,
-                }
-                return (
-                  <div className="space-y-3">
-                    <div className="flex gap-2 sticky top-0 z-10 bg-background pb-1">
-                      <Button
-                        type="button" variant="outline" size="sm" className="h-7 text-xs"
-                        onClick={() => promptDiffRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })}
-                      >
-                        Prompt
-                      </Button>
-                      <Button
-                        type="button" variant="outline" size="sm" className="h-7 text-xs"
-                        onClick={() => settingsDiffRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })}
-                      >
-                        Settings
-                      </Button>
-                    </div>
-
-                    <div ref={promptDiffRef}>
-                      <p className="text-[11px] font-medium text-muted-foreground mb-1">Prompt</p>
-                      <SideBySideDiff
-                        oldText={extractPrompt(publishedFull)}
-                        newText={extractPrompt(currentFull)}
-                      />
-                    </div>
-
-                    <div ref={settingsDiffRef}>
-                      <p className="text-[11px] font-medium text-muted-foreground mb-1">Settings</p>
-                      <SideBySideDiff
-                        oldText={serializeForDiff(publishedSettings)}
-                        newText={serializeForDiff(currentSettings)}
-                      />
-                    </div>
-                  </div>
-                )
-              })() : null}
+            {renderDiffContent()}
 
             {!isDiffLoading && !publishedSnapshot && (
               <p className="text-[11px] text-muted-foreground">No prior published version — this will be the first version.</p>

--- a/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/DropOffCallSettings.tsx
+++ b/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/DropOffCallSettings.tsx
@@ -80,8 +80,12 @@ export default function DropOffCallSettings({
       try {
         setLoading(true)
 
-        // Fetch drop-off settings
-        const settingsResponse = await fetch(`/api/agents/${agentId}/dropoff-settings`)
+        // Fetch drop-off settings and agent metrics in parallel — these two requests
+        // are independent, so awaiting them sequentially just doubles the load time.
+        const [settingsResponse, agentResponse] = await Promise.all([
+          fetch(`/api/agents/${agentId}/dropoff-settings`),
+          fetch(`/api/agents/${agentId}`).catch(() => null),
+        ])
 
         if (!settingsResponse.ok) {
           throw new Error('Failed to fetch drop-off settings')
@@ -93,9 +97,7 @@ export default function DropOffCallSettings({
         let callRetryCriteria: string | null = null
 
         try {
-          const agentResponse = await fetch(`/api/agents/${agentId}`)
-
-          if (agentResponse.ok) {
+          if (agentResponse?.ok) {
             const agentData = await agentResponse.json()
 
             console.log('Agent data fetched:', {
@@ -140,7 +142,7 @@ export default function DropOffCallSettings({
               console.log('No metrics field in agent data')
             }
           } else {
-            console.error('Agent response not OK:', agentResponse.status)
+            console.error('Agent response not OK:', agentResponse?.status)
           }
         } catch (agentError) {
           console.error('Error fetching agent metrics:', agentError)

--- a/src/components/agents/AgentConfig/SideBySideDiff.tsx
+++ b/src/components/agents/AgentConfig/SideBySideDiff.tsx
@@ -1,0 +1,106 @@
+'use client'
+
+import React, { useState } from 'react'
+import { buildSideBySideRows, hasChanges, type DiffRow } from '@/lib/configDiff'
+
+function Cell({ cell, tone }: { cell: { num: number; content: string; changed: boolean } | null; tone: 'left' | 'right' }) {
+  if (!cell) {
+    return <div className="flex bg-muted/30 min-h-[1.25rem]" />
+  }
+  const bg = cell.changed ? (tone === 'left' ? 'bg-red-500/10' : 'bg-green-500/10') : ''
+  const marker = cell.changed ? (tone === 'left' ? '−' : '+') : ' '
+  const markerColor = cell.changed ? (tone === 'left' ? 'text-red-500' : 'text-green-500') : 'text-transparent'
+  return (
+    <div className={`flex ${bg}`}>
+      <span className="w-9 shrink-0 text-right pr-2 py-px text-muted-foreground/60 select-none tabular-nums">{cell.num}</span>
+      <span className={`w-4 shrink-0 py-px select-none font-semibold ${markerColor}`}>{marker}</span>
+      <span className="flex-1 pr-3 py-px whitespace-pre-wrap break-all text-foreground">{cell.content || ' '}</span>
+    </div>
+  )
+}
+
+function CollapsedRow({ count, onExpand }: { count: number; onExpand: () => void }) {
+  return (
+    <div className="col-span-2 grid grid-cols-2 border-y bg-muted/40">
+      <button
+        onClick={onExpand}
+        className="col-span-2 text-left px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-muted/70 transition-colors underline underline-offset-2"
+      >
+        Expand {count} line{count !== 1 ? 's' : ''} ...
+      </button>
+    </div>
+  )
+}
+
+export function SideBySideDiff({
+  oldText,
+  newText,
+  leftLabel = 'Published version',
+  rightLabel = 'Current changes',
+}: {
+  oldText: string
+  newText: string
+  leftLabel?: string
+  rightLabel?: string
+}) {
+  const [expanded, setExpanded] = useState<Set<number>>(new Set())
+  const rows = buildSideBySideRows(oldText, newText, 0)
+
+  if (!hasChanges(rows)) {
+    return (
+      <div className="flex items-center justify-center py-6 rounded-lg border border-dashed text-xs text-muted-foreground">
+        No changes to publish
+      </div>
+    )
+  }
+
+  return (
+    <div className="rounded-lg border overflow-hidden font-mono text-xs leading-5">
+      <div className="grid grid-cols-2 border-b bg-muted/20">
+        <div className="px-3 py-2 flex items-center gap-2 text-[11px] font-medium text-foreground">
+          {leftLabel} <span className="px-1.5 py-0.5 rounded bg-muted text-muted-foreground text-[10px]">Main</span>
+        </div>
+        <div className="px-3 py-2 flex items-center gap-2 text-[11px] font-medium text-foreground border-l">
+          {rightLabel} <span className="px-1.5 py-0.5 rounded bg-muted text-muted-foreground text-[10px]">Main</span>
+        </div>
+      </div>
+
+      <div className="max-h-[65vh] overflow-y-auto">
+        {rows.map((row, idx) => {
+          if (row.type === 'collapsed') {
+            if (expanded.has(idx)) {
+              return (
+                <React.Fragment key={idx}>
+                  {row.rows.map((r, j) => (
+                    <div key={j} className="grid grid-cols-2 border-l-0">
+                      <Cell cell={r.left} tone="left" />
+                      <div className="border-l">
+                        <Cell cell={r.right} tone="right" />
+                      </div>
+                    </div>
+                  ))}
+                </React.Fragment>
+              )
+            }
+            return (
+              <CollapsedRow
+                key={idx}
+                count={row.rows.length}
+                onExpand={() => setExpanded(prev => new Set(prev).add(idx))}
+              />
+            )
+          }
+          return (
+            <div key={idx} className="grid grid-cols-2">
+              <Cell cell={row.left} tone="left" />
+              <div className="border-l">
+                <Cell cell={row.right} tone="right" />
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+    </div>
+  )
+}

--- a/src/components/agents/AgentConfig/SideBySideDiff.tsx
+++ b/src/components/agents/AgentConfig/SideBySideDiff.tsx
@@ -1,32 +1,42 @@
 'use client'
 
 import React, { useState } from 'react'
-import { buildSideBySideRows, hasChanges, type DiffRow } from '@/lib/configDiff'
+import { buildSideBySideRows, hasChanges } from '@/lib/configDiff'
 
-function Cell({ cell, tone }: { cell: { num: number; content: string; changed: boolean } | null; tone: 'left' | 'right' }) {
+const TONE_STYLES = {
+  left: { bg: 'bg-red-500/10', marker: '−', color: 'text-red-500' },
+  right: { bg: 'bg-green-500/10', marker: '+', color: 'text-green-500' },
+} as const
+
+function cellKey(row: { left: { num: number } | null; right: { num: number } | null }, prefix: string): string {
+  return `${prefix}-${row.left?.num ?? '_'}-${row.right?.num ?? '_'}`
+}
+
+function Cell({ cell, tone }: Readonly<{ cell: { num: number; content: string; changed: boolean } | null; tone: 'left' | 'right' }>) {
   if (!cell) {
     return <div className="flex bg-muted/30 min-h-[1.25rem]" />
   }
-  const bg = cell.changed ? (tone === 'left' ? 'bg-red-500/10' : 'bg-green-500/10') : ''
-  const marker = cell.changed ? (tone === 'left' ? '−' : '+') : ' '
-  const markerColor = cell.changed ? (tone === 'left' ? 'text-red-500' : 'text-green-500') : 'text-transparent'
+  const style = TONE_STYLES[tone]
+  const bg = cell.changed ? style.bg : ''
+  const marker = cell.changed ? style.marker : ' '
+  const markerColor = cell.changed ? style.color : 'text-transparent'
   return (
     <div className={`flex ${bg}`}>
       <span className="w-9 shrink-0 text-right pr-2 py-px text-muted-foreground/60 select-none tabular-nums">{cell.num}</span>
       <span className={`w-4 shrink-0 py-px select-none font-semibold ${markerColor}`}>{marker}</span>
-      <span className="flex-1 pr-3 py-px whitespace-pre-wrap break-all text-foreground">{cell.content || ' '}</span>
+      <span className="flex-1 pr-3 py-px whitespace-pre-wrap break-all text-foreground">{cell.content || ' '}</span>
     </div>
   )
 }
 
-function CollapsedRow({ count, onExpand }: { count: number; onExpand: () => void }) {
+function CollapsedRow({ count, onExpand }: Readonly<{ count: number; onExpand: () => void }>) {
   return (
     <div className="col-span-2 grid grid-cols-2 border-y bg-muted/40">
       <button
         onClick={onExpand}
         className="col-span-2 text-left px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-muted/70 transition-colors underline underline-offset-2"
       >
-        Expand {count} line{count !== 1 ? 's' : ''} ...
+        Expand {count} {count === 1 ? 'line' : 'lines'} ...
       </button>
     </div>
   )
@@ -37,12 +47,12 @@ export function SideBySideDiff({
   newText,
   leftLabel = 'Published version',
   rightLabel = 'Current changes',
-}: {
+}: Readonly<{
   oldText: string
   newText: string
   leftLabel?: string
   rightLabel?: string
-}) {
+}>) {
   const [expanded, setExpanded] = useState<Set<number>>(new Set())
   const rows = buildSideBySideRows(oldText, newText, 0)
 
@@ -68,11 +78,12 @@ export function SideBySideDiff({
       <div className="max-h-[65vh] overflow-y-auto">
         {rows.map((row, idx) => {
           if (row.type === 'collapsed') {
+            const groupKey = cellKey(row.rows[0] ?? { left: null, right: null }, 'collapsed')
             if (expanded.has(idx)) {
               return (
-                <React.Fragment key={idx}>
-                  {row.rows.map((r, j) => (
-                    <div key={j} className="grid grid-cols-2 border-l-0">
+                <React.Fragment key={groupKey}>
+                  {row.rows.map(r => (
+                    <div key={cellKey(r, 'expanded')} className="grid grid-cols-2 border-l-0">
                       <Cell cell={r.left} tone="left" />
                       <div className="border-l">
                         <Cell cell={r.right} tone="right" />
@@ -84,14 +95,14 @@ export function SideBySideDiff({
             }
             return (
               <CollapsedRow
-                key={idx}
+                key={groupKey}
                 count={row.rows.length}
                 onExpand={() => setExpanded(prev => new Set(prev).add(idx))}
               />
             )
           }
           return (
-            <div key={idx} className="grid grid-cols-2">
+            <div key={cellKey(row, 'row')} className="grid grid-cols-2">
               <Cell cell={row.left} tone="left" />
               <div className="border-l">
                 <Cell cell={row.right} tone="right" />
@@ -100,7 +111,6 @@ export function SideBySideDiff({
           )
         })}
       </div>
-
     </div>
   )
 }

--- a/src/lib/configDiff.ts
+++ b/src/lib/configDiff.ts
@@ -11,7 +11,7 @@ function canonicalize(value: any): any {
   if (Array.isArray(value)) return value.map(canonicalize)
   if (value && typeof value === 'object') {
     const sorted: Record<string, any> = {}
-    for (const key of Object.keys(value).sort()) sorted[key] = canonicalize(value[key])
+    for (const key of Object.keys(value).sort((a, b) => a.localeCompare(b))) sorted[key] = canonicalize(value[key])
     return sorted
   }
   return value
@@ -27,7 +27,7 @@ export function extractPrompt(config: any): string {
 
 export function omitPrompt(config: any): any {
   if (!config) return config
-  const clone = JSON.parse(JSON.stringify(config))
+  const clone = structuredClone(config)
   if (clone?.agent?.assistant?.[0]) delete clone.agent.assistant[0].prompt
   if (clone?.agent) delete clone.agent.prompt
   return clone
@@ -35,7 +35,7 @@ export function omitPrompt(config: any): any {
 
 export function sanitizeForDiff(config: any): any {
   if (!config) return config
-  const clone = JSON.parse(JSON.stringify(config))
+  const clone = structuredClone(config)
   if (clone?.agent) {
     for (const key of DIFF_NOISE_KEYS) delete clone.agent[key]
   }
@@ -55,8 +55,9 @@ export function serializeForDiff(value: any, indent = 0): string {
   if (value === null || value === undefined) return 'null'
 
   if (typeof value === 'string') {
-    if (value.includes('\n')) return `"${value.replace(/\n/g, `\n${childPad}`)}"`
-    return JSON.stringify(value)
+    if (!value.includes('\n')) return JSON.stringify(value)
+    const indented = value.replaceAll('\n', `\n${childPad}`)
+    return `"${indented}"`
   }
 
   if (typeof value !== 'object') return JSON.stringify(value)
@@ -97,13 +98,47 @@ function toLines(text: string): string[] {
   return text.endsWith('\n') ? text.slice(0, -1).split('\n') : text.split('\n')
 }
 
-// Builds a side-by-side (old | new) diff of two texts. Unchanged runs longer
-// than `context` lines on each side of a change are collapsed into a group.
-export function buildSideBySideRows(oldText: string, newText: string, context = 2): DiffRow[] {
+// Consumes one removed/added run (or a removed run immediately followed by
+// an added run) starting at `i`, returning the paired-up "changed" rows and
+// the index to resume scanning from.
+function pairChangeBlock(
+  changes: ReturnType<typeof diffLines>,
+  i: number,
+  counters: { leftNum: number; rightNum: number }
+): { rows: SideBySideRow[]; nextIndex: number } {
+  let removedLines: string[] = []
+  let addedLines: string[] = []
+  let nextIndex = i
+
+  if (changes[nextIndex].removed) {
+    removedLines = toLines(changes[nextIndex].value)
+    nextIndex++
+    if (nextIndex < changes.length && changes[nextIndex].added) {
+      addedLines = toLines(changes[nextIndex].value)
+      nextIndex++
+    }
+  } else {
+    addedLines = toLines(changes[nextIndex].value)
+    nextIndex++
+  }
+
+  const rows: SideBySideRow[] = []
+  const max = Math.max(removedLines.length, addedLines.length)
+  for (let k = 0; k < max; k++) {
+    const left = k < removedLines.length ? { num: counters.leftNum++, content: removedLines[k], changed: true } : null
+    const right = k < addedLines.length ? { num: counters.rightNum++, content: addedLines[k], changed: true } : null
+    rows.push({ type: 'changed', left, right })
+  }
+
+  return { rows, nextIndex }
+}
+
+// Flattens diffLines' output into one row per line, pairing up removed/added
+// runs so they sit side-by-side (a "changed" row per line pair).
+function buildChangeRows(oldText: string, newText: string): SideBySideRow[] {
   const changes = diffLines(oldText ?? '', newText ?? '')
   const rows: SideBySideRow[] = []
-  let leftNum = 1
-  let rightNum = 1
+  const counters = { leftNum: 1, rightNum: 1 }
   let i = 0
 
   while (i < changes.length) {
@@ -113,37 +148,25 @@ export function buildSideBySideRows(oldText: string, newText: string, context = 
       for (const line of toLines(change.value)) {
         rows.push({
           type: 'unchanged',
-          left: { num: leftNum++, content: line, changed: false },
-          right: { num: rightNum++, content: line, changed: false },
+          left: { num: counters.leftNum++, content: line, changed: false },
+          right: { num: counters.rightNum++, content: line, changed: false },
         })
       }
       i++
       continue
     }
 
-    let removedLines: string[] = []
-    let addedLines: string[] = []
-
-    if (change.removed) {
-      removedLines = toLines(change.value)
-      i++
-      if (i < changes.length && changes[i].added) {
-        addedLines = toLines(changes[i].value)
-        i++
-      }
-    } else {
-      addedLines = toLines(change.value)
-      i++
-    }
-
-    const max = Math.max(removedLines.length, addedLines.length)
-    for (let k = 0; k < max; k++) {
-      const left = k < removedLines.length ? { num: leftNum++, content: removedLines[k], changed: true } : null
-      const right = k < addedLines.length ? { num: rightNum++, content: addedLines[k], changed: true } : null
-      rows.push({ type: 'changed', left, right })
-    }
+    const block = pairChangeBlock(changes, i, counters)
+    rows.push(...block.rows)
+    i = block.nextIndex
   }
 
+  return rows
+}
+
+// Collapses unchanged runs longer than `context` lines (on each side of a
+// change) into a single group, keeping the rest of the diff readable.
+function collapseUnchangedRuns(rows: SideBySideRow[], context: number): DiffRow[] {
   const show = new Set<number>()
   rows.forEach((row, idx) => {
     if (row.type === 'changed') {
@@ -154,19 +177,25 @@ export function buildSideBySideRows(oldText: string, newText: string, context = 
   const result: DiffRow[] = []
   let bucket: SideBySideRow[] = []
   rows.forEach((row, idx) => {
-    if (show.has(idx)) {
-      if (bucket.length) {
-        result.push({ type: 'collapsed', rows: bucket })
-        bucket = []
-      }
-      result.push(row)
-    } else {
+    if (!show.has(idx)) {
       bucket.push(row)
+      return
     }
+    if (bucket.length) {
+      result.push({ type: 'collapsed', rows: bucket })
+      bucket = []
+    }
+    result.push(row)
   })
   if (bucket.length) result.push({ type: 'collapsed', rows: bucket })
 
   return result
+}
+
+// Builds a side-by-side (old | new) diff of two texts. Unchanged runs longer
+// than `context` lines on each side of a change are collapsed into a group.
+export function buildSideBySideRows(oldText: string, newText: string, context = 2): DiffRow[] {
+  return collapseUnchangedRuns(buildChangeRows(oldText, newText), context)
 }
 
 export function hasChanges(rows: DiffRow[]): boolean {

--- a/src/lib/configDiff.ts
+++ b/src/lib/configDiff.ts
@@ -1,0 +1,174 @@
+import { diffLines } from 'diff'
+
+// Keys that always differ between snapshots (secrets, hashes) and would show
+// as noise in a diff even when nothing meaningful changed.
+const DIFF_NOISE_KEYS = ['whispey_api_key', 'token_hash', 'whispey_key_id']
+
+// Recursively sorts object keys so two objects with identical values but
+// different key insertion order serialize to identical text (arrays keep
+// their order since it's semantically meaningful, e.g. tool/filler lists).
+function canonicalize(value: any): any {
+  if (Array.isArray(value)) return value.map(canonicalize)
+  if (value && typeof value === 'object') {
+    const sorted: Record<string, any> = {}
+    for (const key of Object.keys(value).sort()) sorted[key] = canonicalize(value[key])
+    return sorted
+  }
+  return value
+}
+
+// Splits a sanitized config into its prompt text and everything else, so the
+// diff view can show "Prompt" and "Settings" as separate, independently
+// navigable sections. Mirrors the same prompt lookup used elsewhere
+// (agentVersionHelpers/ConfigHistory) so both agree on where the prompt lives.
+export function extractPrompt(config: any): string {
+  return config?.agent?.assistant?.[0]?.prompt ?? config?.agent?.prompt ?? ''
+}
+
+export function omitPrompt(config: any): any {
+  if (!config) return config
+  const clone = JSON.parse(JSON.stringify(config))
+  if (clone?.agent?.assistant?.[0]) delete clone.agent.assistant[0].prompt
+  if (clone?.agent) delete clone.agent.prompt
+  return clone
+}
+
+export function sanitizeForDiff(config: any): any {
+  if (!config) return config
+  const clone = JSON.parse(JSON.stringify(config))
+  if (clone?.agent) {
+    for (const key of DIFF_NOISE_KEYS) delete clone.agent[key]
+  }
+  return canonicalize(clone)
+}
+
+// JSON.stringify escapes real newlines inside string values as literal "\n",
+// which collapses a multi-line prompt onto a single line of diff text — any
+// tiny edit then makes the diff flag the *entire* prompt as changed. This
+// serializer keeps embedded newlines as real line breaks instead, so the
+// line-diff aligns prompt text line-by-line. Output is diff-display text
+// only — not meant to be parsed back as JSON.
+export function serializeForDiff(value: any, indent = 0): string {
+  const pad = '  '.repeat(indent)
+  const childPad = '  '.repeat(indent + 1)
+
+  if (value === null || value === undefined) return 'null'
+
+  if (typeof value === 'string') {
+    if (value.includes('\n')) return `"${value.replace(/\n/g, `\n${childPad}`)}"`
+    return JSON.stringify(value)
+  }
+
+  if (typeof value !== 'object') return JSON.stringify(value)
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) return '[]'
+    const items = value.map(v => `${childPad}${serializeForDiff(v, indent + 1)}`)
+    return `[\n${items.join(',\n')}\n${pad}]`
+  }
+
+  const keys = Object.keys(value)
+  if (keys.length === 0) return '{}'
+  const items = keys.map(k => `${childPad}${JSON.stringify(k)}: ${serializeForDiff(value[k], indent + 1)}`)
+  return `{\n${items.join(',\n')}\n${pad}}`
+}
+
+export interface DiffCell {
+  num: number
+  content: string
+  changed: boolean
+}
+
+export interface SideBySideRow {
+  type: 'unchanged' | 'changed'
+  left: DiffCell | null
+  right: DiffCell | null
+}
+
+export interface CollapsedGroup {
+  type: 'collapsed'
+  rows: SideBySideRow[]
+}
+
+export type DiffRow = SideBySideRow | CollapsedGroup
+
+function toLines(text: string): string[] {
+  if (!text) return []
+  return text.endsWith('\n') ? text.slice(0, -1).split('\n') : text.split('\n')
+}
+
+// Builds a side-by-side (old | new) diff of two texts. Unchanged runs longer
+// than `context` lines on each side of a change are collapsed into a group.
+export function buildSideBySideRows(oldText: string, newText: string, context = 2): DiffRow[] {
+  const changes = diffLines(oldText ?? '', newText ?? '')
+  const rows: SideBySideRow[] = []
+  let leftNum = 1
+  let rightNum = 1
+  let i = 0
+
+  while (i < changes.length) {
+    const change = changes[i]
+
+    if (!change.added && !change.removed) {
+      for (const line of toLines(change.value)) {
+        rows.push({
+          type: 'unchanged',
+          left: { num: leftNum++, content: line, changed: false },
+          right: { num: rightNum++, content: line, changed: false },
+        })
+      }
+      i++
+      continue
+    }
+
+    let removedLines: string[] = []
+    let addedLines: string[] = []
+
+    if (change.removed) {
+      removedLines = toLines(change.value)
+      i++
+      if (i < changes.length && changes[i].added) {
+        addedLines = toLines(changes[i].value)
+        i++
+      }
+    } else {
+      addedLines = toLines(change.value)
+      i++
+    }
+
+    const max = Math.max(removedLines.length, addedLines.length)
+    for (let k = 0; k < max; k++) {
+      const left = k < removedLines.length ? { num: leftNum++, content: removedLines[k], changed: true } : null
+      const right = k < addedLines.length ? { num: rightNum++, content: addedLines[k], changed: true } : null
+      rows.push({ type: 'changed', left, right })
+    }
+  }
+
+  const show = new Set<number>()
+  rows.forEach((row, idx) => {
+    if (row.type === 'changed') {
+      for (let k = Math.max(0, idx - context); k <= Math.min(rows.length - 1, idx + context); k++) show.add(k)
+    }
+  })
+
+  const result: DiffRow[] = []
+  let bucket: SideBySideRow[] = []
+  rows.forEach((row, idx) => {
+    if (show.has(idx)) {
+      if (bucket.length) {
+        result.push({ type: 'collapsed', rows: bucket })
+        bucket = []
+      }
+      result.push(row)
+    } else {
+      bucket.push(row)
+    }
+  })
+  if (bucket.length) result.push({ type: 'collapsed', rows: bucket })
+
+  return result
+}
+
+export function hasChanges(rows: DiffRow[]): boolean {
+  return rows.some(r => r.type === 'changed')
+}

--- a/src/lib/supplementalSettings.ts
+++ b/src/lib/supplementalSettings.ts
@@ -45,7 +45,7 @@ function isValidHttpUrl(url: string): boolean {
 }
 
 async function saveWebhook(agentId: string, projectId: string, cfg: WebhookConfig): Promise<void> {
-  if (!cfg.isActive && !cfg.webhookUrl.trim()) {
+  if (!cfg.webhookUrl.trim()) {
     await fetch(`/api/webhooks/config?agent_id=${agentId}`, { method: 'DELETE' })
     return
   }


### PR DESCRIPTION
**Summary**

  - Adds an ElevenLabs-style side-by-side diff to the "Update Config" commit modal, so changes are reviewed (Prompt vs.
  Settings, each independently jumpable) before publishing to Supabase version history.
  - Fixes two pre-existing bugs surfaced while building this: webhook removal incorrectly requiring a URL, and pasted
  webhook/dropoff/callback settings getting silently overwritten by stale saved data when their config section is expanded
  later.
  - Speeds up the Drop-off settings section load by parallelizing two sequential network requests.