### PR TITLE
Add AWS Bedrock (GLM 5) as an LLM provider option

### DIFF
--- a/src/components/agents/AgentConfig/ModelSelector.tsx
+++ b/src/components/agents/AgentConfig/ModelSelector.tsx
@@ -113,6 +113,15 @@ const modelProviders: Record<string, Provider> = {
       { value: 'gpt-4.1-mini', label: 'GPT 4.1 Mini', deploymentName: 'gpt-4.1-mini-2' },
     ]
   },
+  aws: {
+    label: 'AWS Bedrock',
+    icon: 'Aw',
+    color: 'bg-orange-500',
+    type: 'direct',
+    models: [
+      { value: 'zai.glm-5', label: 'Z.ai GLM 5' },
+    ]
+  },
   groq: {
     label: 'Groq',
     icon: 'G',
@@ -180,6 +189,7 @@ const getProviderIcon = (providerKey: string) => {
     groq: <Cpu className="h-3 w-3" />,
     google: <Cloud className="h-3 w-3" />,
     azure_openai: <Cloud className="h-3 w-3" />,
+    aws: <Cloud className="h-3 w-3" />,
     cerebras: <Cpu className="h-3 w-3" />
   }
   return iconMap[providerKey]


### PR DESCRIPTION
## Summary
- Add "AWS Bedrock" as a selectable LLM provider in `ModelSelector.tsx`, listed directly below Azure OpenAI, with `zai.glm-5` (Z.ai GLM 5) as its first model

## Details
- Registered as a `direct`-type provider (like OpenAI/Google/Groq/Cerebras) rather than `config`-type like Azure, since Bedrock auth is handled entirely server-side via AWS credentials — no per-agent endpoint/deployment fields needed in the UI
- Provider key `aws` maps 1:1 to the backend's `llm.provider` value, so no special-case translation was needed in `useAgentConfig.ts` / `useMultiAssistantState.ts` (both already fall through generically for non-Azure providers)
- Added an icon mapping entry for the new provider key
