### PR TITLE
Fix double transcript (frontend + sdk)

### DIFF
--- a/sdk/whispey/whispey.py
+++ b/sdk/whispey/whispey.py
@@ -1016,8 +1016,20 @@ async def send_session_to_whispey(session_id: str, recording_url: str = "", addi
     if session_id not in _session_data_store:
         logger.error(f"Session {session_id} not found in data store")
         return {"success": False, "error": "Session not found"}
-    
+
     session_info = _session_data_store[session_id]
+
+    # Guard against duplicate sends: multiple independent call paths (transfer,
+    # end_call tool, EOD silence timeout, normal shutdown) can all reach this
+    # function for the same session. Checked+set synchronously (no await in
+    # between) so a concurrent second call sees it immediately and skips
+    # instead of re-sending the same data. Cleared on failure so retries still
+    # work — only a successful send should permanently block re-sends.
+    if session_info.get('_export_in_progress'):
+        logger.info(f"⏭️ Export already in progress/sent for {session_id} — skipping duplicate call")
+        return {"success": True, "skipped": True}
+    session_info['_export_in_progress'] = True
+
     # Use session-stored apikey/api_url if not passed (same as call_started)
     apikey = apikey if apikey is not None else session_info.get("apikey")
     api_url = api_url if api_url is not None else session_info.get("api_url")
@@ -1058,13 +1070,15 @@ async def send_session_to_whispey(session_id: str, recording_url: str = "", addi
             cleanup_session(session_id)
         else:
             logger.error(f"❌ Whispey API returned failure: {result}")
-        
+            session_info['_export_in_progress'] = False  # allow a retry
+
         return result
-        
+
     except Exception as e:
         logger.error(f"❌ Exception sending to Whispey: {e}")
         import traceback
         traceback.print_exc()
+        session_info['_export_in_progress'] = False  # allow a retry
         return {"success": False, "error": str(e)}
 
 

--- a/src/hooks/useVoiceAgent.ts
+++ b/src/hooks/useVoiceAgent.ts
@@ -103,8 +103,10 @@ export function useVoiceAgent({ agentName, mode, sessionEndpoint = '/api/agents/
   const connectionTimeInterval = useRef<NodeJS.Timeout | null>(null)
   const audioElementsRef       = useRef<Set<HTMLAudioElement>>(new Set())
   const roomRef                = useRef<Room | null>(null)
+  const isConnectedRef         = useRef(isConnected)
 
   useEffect(() => { roomRef.current = room }, [room])
+  useEffect(() => { isConnectedRef.current = isConnected }, [isConnected])
 
   useEffect(() => {
     if (isConnected) {
@@ -291,12 +293,20 @@ export function useVoiceAgent({ agentName, mode, sessionEndpoint = '/api/agents/
   }, [isConnected, upsertTranscript])
 
   useEffect(() => {
+    // Unmount-only cleanup. `isConnected` is intentionally NOT a dependency —
+    // it used to be, which made this cleanup re-run on every connect/disconnect
+    // transition (not just unmount), calling roomRef.current.disconnect() a
+    // second time right after the disconnect() action already called it,
+    // which is what triggered the "Unknown DataChannel error on lossy" console
+    // error (the browser firing a generic error event on a data channel that's
+    // already mid-teardown). isConnectedRef stays current via the effect above,
+    // so we still only disconnect here if a room was actually left connected.
     return () => {
-      try { if (roomRef.current && isConnected) roomRef.current.disconnect() } catch {}
+      try { if (roomRef.current && isConnectedRef.current) roomRef.current.disconnect() } catch {}
       cleanupAudioElements()
       if (connectionTimeInterval.current) clearInterval(connectionTimeInterval.current)
     }
-  }, [isConnected, cleanupAudioElements])
+  }, [cleanupAudioElements])
 
   return [
     { room, isConnected, isConnecting, connectionError, transcripts, agentParticipant, agentState, isMuted, volume, connectionTime, webSession },


### PR DESCRIPTION
**File:** `handlers/event_handlers.py` — `CorrectedTranscriptCollector.on_conversation_item_added()`

**Bug:** A conversation "turn" was closed the instant the agent said *anything*. But when a tool call is involved, the agent can speak twice in one logical turn — once as filler ("let me check that...") before the tool runs, and again with the real answer after. The old logic treated the filler message as the end of the turn, so the tool call ended up attached to a brand-new, disconnected turn with no user question and no final response next to it.

**Fix:** A turn no longer closes on the agent's first sentence. It stays open — accumulating any further assistant text — until either the *next* user message starts, or the session ends (`finalize_session()`, unchanged). Tool calls now always land on the same turn as the question that triggered them and the response that followed.
