### PR TITLE
Fix double transcript (frontend + sdk)

### DIFF
--- a/sdk/whispey/whispey.py
+++ b/sdk/whispey/whispey.py
@@ -1016,8 +1016,20 @@ async def send_session_to_whispey(session_id: str, recording_url: str = "", addi
     if session_id not in _session_data_store:
         logger.error(f"Session {session_id} not found in data store")
         return {"success": False, "error": "Session not found"}
-    
+
     session_info = _session_data_store[session_id]
+
+    # Guard against duplicate sends: multiple independent call paths (transfer,
+    # end_call tool, EOD silence timeout, normal shutdown) can all reach this
+    # function for the same session. Checked+set synchronously (no await in
+    # between) so a concurrent second call sees it immediately and skips
+    # instead of re-sending the same data. Cleared on failure so retries still
+    # work — only a successful send should permanently block re-sends.
+    if session_info.get('_export_in_progress'):
+        logger.info(f"⏭️ Export already in progress/sent for {session_id} — skipping duplicate call")
+        return {"success": True, "skipped": True}
+    session_info['_export_in_progress'] = True
+
     # Use session-stored apikey/api_url if not passed (same as call_started)
     apikey = apikey if apikey is not None else session_info.get("apikey")
     api_url = api_url if api_url is not None else session_info.get("api_url")
@@ -1058,13 +1070,15 @@ async def send_session_to_whispey(session_id: str, recording_url: str = "", addi
             cleanup_session(session_id)
         else:
             logger.error(f"❌ Whispey API returned failure: {result}")
-        
+            session_info['_export_in_progress'] = False  # allow a retry
+
         return result
-        
+
     except Exception as e:
         logger.error(f"❌ Exception sending to Whispey: {e}")
         import traceback
         traceback.print_exc()
+        session_info['_export_in_progress'] = False  # allow a retry
         return {"success": False, "error": str(e)}
 
 

--- a/src/hooks/useVoiceAgent.ts
+++ b/src/hooks/useVoiceAgent.ts
@@ -103,8 +103,10 @@ export function useVoiceAgent({ agentName, mode, sessionEndpoint = '/api/agents/
   const connectionTimeInterval = useRef<NodeJS.Timeout | null>(null)
   const audioElementsRef       = useRef<Set<HTMLAudioElement>>(new Set())
   const roomRef                = useRef<Room | null>(null)
+  const isConnectedRef         = useRef(isConnected)
 
   useEffect(() => { roomRef.current = room }, [room])
+  useEffect(() => { isConnectedRef.current = isConnected }, [isConnected])
 
   useEffect(() => {
     if (isConnected) {
@@ -291,12 +293,20 @@ export function useVoiceAgent({ agentName, mode, sessionEndpoint = '/api/agents/
   }, [isConnected, upsertTranscript])
 
   useEffect(() => {
+    // Unmount-only cleanup. `isConnected` is intentionally NOT a dependency —
+    // it used to be, which made this cleanup re-run on every connect/disconnect
+    // transition (not just unmount), calling roomRef.current.disconnect() a
+    // second time right after the disconnect() action already called it,
+    // which is what triggered the "Unknown DataChannel error on lossy" console
+    // error (the browser firing a generic error event on a data channel that's
+    // already mid-teardown). isConnectedRef stays current via the effect above,
+    // so we still only disconnect here if a room was actually left connected.
     return () => {
-      try { if (roomRef.current && isConnected) roomRef.current.disconnect() } catch {}
+      try { if (roomRef.current && isConnectedRef.current) roomRef.current.disconnect() } catch {}
       cleanupAudioElements()
       if (connectionTimeInterval.current) clearInterval(connectionTimeInterval.current)
     }
-  }, [isConnected, cleanupAudioElements])
+  }, [cleanupAudioElements])
 
   return [
     { room, isConnected, isConnecting, connectionError, transcripts, agentParticipant, agentState, isMuted, volume, connectionTime, webSession },


### PR DESCRIPTION
# Fix Summary

## SDK — `whispey` repo (`sdk/whispey/whispey.py`)

**Function:** `send_session_to_whispey()`

**Bug:** No protection against being called more than once for the same call. Multiple independent backend paths (normal shutdown, `end_call` tool, EOD/silence timeout, transfer flow) can each trigger an export. The only "already sent" flag was checked once at the top, then the function spent 1+ seconds `await`ing other work before actually sending — leaving a window where a second trigger could slip through and re-send the exact same data, producing exact duplicate rows in `pype_voice_call_logs` and `pype_voice_metrics_logs`.

**Fix:** Added a guard (`_export_in_progress`) checked and set synchronously, before any `await`, so a concurrent second call for the same session sees it immediately and skips instead of re-sending. Cleared on failure so a genuinely failed send can still be retried later.

**Verified:** simulated two concurrent calls → exactly one real send; simulated a failed send → confirmed a later retry still succeeds.

---

## Frontend — `whispey` repo (`src/hooks/useVoiceAgent.ts`)

**Bug:** The unmount-cleanup effect had `isConnected` in its dependency array, so it re-ran on *every* connect/disconnect transition instead of only on actual component unmount. On every hangup of the "Talk to Assistant" web test-call widget, this caused `room.disconnect()` to be called a second time, right after the explicit disconnect action already called it once — triggering the browser to fire a generic, detail-less `error` event on the WebRTC data channel, logged as `"Unknown DataChannel error on lossy {}"`.

**Fix:** The cleanup now runs only on true component unmount (empty dependency array). Connection state at unmount time is read from a ref (`isConnectedRef`, kept current by a small sync effect) instead of the stale closure variable, so the double-disconnect no longer happens.

**Scope note:** this only affects the browser-side web test-call widget — it has no bearing on real phone/SIP calls or the backend transfer flow.