### PR TITLE
campaign retry config + temporarily restrict Retry codes to 480/486

### DIFF
--- a/src/components/campaigns/RetryConfiguration.tsx
+++ b/src/components/campaigns/RetryConfiguration.tsx
@@ -9,7 +9,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { RefreshCw, Info, Plus, X, Loader2 } from 'lucide-react'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
-import { RetryConfig, VALID_SIP_ERROR_CODES, SIP_CODE_GROUPS, SipCodeGroup as SipCodeGroupType } from '@/utils/campaigns/constants'
+import { RetryConfig, VALID_SIP_ERROR_CODES, SIP_CODE_GROUPS, SipCode, SipCodeGroup as SipCodeGroupType } from '@/utils/campaigns/constants'
 
 // Chip-style input: type a value, press Enter/Add to append it (after
 // validation), click the X on a chip to remove it. Used for both SIP error
@@ -195,6 +195,12 @@ function SipCodePicker({
   )
 }
 
+function sipCodeButtonTitle(c: SipCode, usedElsewhere: boolean): string {
+  if (c.enabled && usedElsewhere) return `${c.code} is already used in another retry rule`
+  if (c.enabled) return c.description
+  return `${c.code} — coming soon`
+}
+
 function SipCodeGroup({
   group,
   errorCodes,
@@ -236,11 +242,7 @@ function SipCodeGroup({
           const selected = errorCodes.includes(c.code)
           const usedElsewhere = !selected && isUsedElsewhere(c.code)
           const disabled = !c.enabled || usedElsewhere
-          const title = !c.enabled
-            ? `${c.code} — coming soon`
-            : usedElsewhere
-              ? `${c.code} is already used in another retry rule`
-              : c.description
+          const title = sipCodeButtonTitle(c, usedElsewhere)
           return (
             <button
               key={c.code}

--- a/src/components/campaigns/RetryConfiguration.tsx
+++ b/src/components/campaigns/RetryConfiguration.tsx
@@ -165,6 +165,9 @@ function SipCodePicker({
                     {c.code}
                   </span>{' '}
                   <span className="font-medium text-gray-900 dark:text-gray-100">{c.label}</span>
+                  {!c.enabled && (
+                    <span className="ml-1 text-[10px] italic text-gray-400">(coming soon)</span>
+                  )}
                   <p className="text-gray-500 dark:text-gray-400">{c.description}</p>
                 </div>
               ))}
@@ -206,8 +209,11 @@ function SipCodeGroup({
   onSelectAll: (addable: string[]) => void
 }>) {
   const groupCodes = group.codes
+  // Only enabled, unclaimed codes can be picked up by "select all" — the
+  // rest are temporarily disabled ("Coming soon") while retry-count/backoff
+  // behavior is under RCA. Frontend-only gate; validation still accepts all.
   const addable = groupCodes
-    .filter((c) => !errorCodes.includes(c.code) && !isUsedElsewhere(c.code))
+    .filter((c) => c.enabled && !errorCodes.includes(c.code) && !isUsedElsewhere(c.code))
     .map((c) => c.code)
 
   return (
@@ -229,12 +235,18 @@ function SipCodeGroup({
         {groupCodes.map((c) => {
           const selected = errorCodes.includes(c.code)
           const usedElsewhere = !selected && isUsedElsewhere(c.code)
+          const disabled = !c.enabled || usedElsewhere
+          const title = !c.enabled
+            ? `${c.code} — coming soon`
+            : usedElsewhere
+              ? `${c.code} is already used in another retry rule`
+              : c.description
           return (
             <button
               key={c.code}
               type="button"
-              disabled={usedElsewhere}
-              title={usedElsewhere ? `${c.code} is already used in another retry rule` : c.description}
+              disabled={disabled}
+              title={title}
               onClick={() => onToggleCode(c.code, selected)}
               className={
                 selected
@@ -243,6 +255,7 @@ function SipCodeGroup({
               }
             >
               {c.code} — {c.label}
+              {!c.enabled && <span className="ml-1 text-[10px] italic">(coming soon)</span>}
             </button>
           )
         })}

--- a/src/utils/campaigns/constants.ts
+++ b/src/utils/campaigns/constants.ts
@@ -74,6 +74,13 @@ export interface SipCode {
   code: string
   label: string
   description: string
+  // Frontend-only picker gate — does NOT affect what the Yup schema or the
+  // schedule API route accept (VALID_SIP_ERROR_CODE_VALUES is intentionally
+  // left unfiltered). Temporary: while we RCA the retry-count/backoff-order
+  // issues seen with the full 9-code set, the picker only lets a user select
+  // the pre-existing 480/486; the rest render disabled as "Coming soon" so
+  // the groups/UI don't need rebuilding once codes are re-enabled.
+  enabled: boolean
 }
 
 export interface SipCodeGroup {
@@ -108,6 +115,7 @@ const sipCodeSchema = z.object({
   code: z.string().regex(/^\d{3}$/, 'SIP code must be a 3-digit string'),
   label: z.string().min(1),
   description: z.string().min(1),
+  enabled: z.boolean(),
 })
 
 const sipCodeGroupSchema = z.object({

--- a/src/utils/campaigns/constants.ts
+++ b/src/utils/campaigns/constants.ts
@@ -140,8 +140,16 @@ function loadSipCodeGroups(raw: unknown): SipCodeGroup[] {
 
 export const SIP_CODE_GROUPS: SipCodeGroup[] = loadSipCodeGroups(sipCodeGroupsRaw)
 
+// All 9 codes, including disabled ones — used for UI display (grouped
+// picker, info popover) so "coming soon" codes still render with labels.
 export const VALID_SIP_ERROR_CODES: SipCode[] = SIP_CODE_GROUPS.flatMap(g => g.codes)
-export const VALID_SIP_ERROR_CODE_VALUES = VALID_SIP_ERROR_CODES.map(c => c.code)
+
+// Only enabled codes — this is what the Yup schema and schedule/route.ts's
+// backend validator actually accept. Filtered (not the full list above) so a
+// disabled code is rejected even via a direct API call, not just blocked in
+// the picker UI. Temporary, pending RCA on the retry-count/backoff-order
+// issue seen with the full 9-code set (see sip-codes.data.json comments).
+export const VALID_SIP_ERROR_CODE_VALUES = VALID_SIP_ERROR_CODES.filter(c => c.enabled).map(c => c.code)
 
 // Retry Configuration
 export interface RetryConfig {

--- a/src/utils/campaigns/sip-codes.data.json
+++ b/src/utils/campaigns/sip-codes.data.json
@@ -6,12 +6,14 @@
       {
         "code": "480",
         "label": "Temporarily Unavailable",
-        "description": "Callee's device was reached but is currently unavailable (not registered, do-not-disturb, etc). May succeed on retry."
+        "description": "Callee's device was reached but is currently unavailable (not registered, do-not-disturb, etc). May succeed on retry.",
+        "enabled": true
       },
       {
         "code": "487",
         "label": "Request Terminated",
-        "description": "Call was canceled/ended before being answered."
+        "description": "Call was canceled/ended before being answered.",
+        "enabled": false
       }
     ]
   },
@@ -22,12 +24,14 @@
       {
         "code": "486",
         "label": "Busy Here",
-        "description": "Callee is on another call. May succeed on retry once they hang up."
+        "description": "Callee is on another call. May succeed on retry once they hang up.",
+        "enabled": true
       },
       {
         "code": "600",
         "label": "Busy Everywhere",
-        "description": "Callee is busy or has do-not-disturb enabled across all their devices. May succeed once that's turned off."
+        "description": "Callee is busy or has do-not-disturb enabled across all their devices. May succeed once that's turned off.",
+        "enabled": false
       }
     ]
   },
@@ -38,12 +42,14 @@
       {
         "code": "408",
         "label": "Request Timeout",
-        "description": "Server/network couldn't reach the destination in time. Usually a transient network issue."
+        "description": "Server/network couldn't reach the destination in time. Usually a transient network issue.",
+        "enabled": false
       },
       {
         "code": "504",
         "label": "Server Timeout",
-        "description": "Upstream server took too long to respond. Same timeout bucket as 408 — usually transient."
+        "description": "Upstream server took too long to respond. Same timeout bucket as 408 — usually transient.",
+        "enabled": false
       }
     ]
   },
@@ -54,12 +60,14 @@
       {
         "code": "500",
         "label": "Server Internal Error",
-        "description": "Telephony server hit a transient internal error. Categorized as network_error — usually resolves on retry."
+        "description": "Telephony server hit a transient internal error. Categorized as network_error — usually resolves on retry.",
+        "enabled": false
       },
       {
         "code": "503",
         "label": "Service Unavailable",
-        "description": "Telephony server is overloaded or temporarily down. Categorized as network_error — often self-resolves."
+        "description": "Telephony server is overloaded or temporarily down. Categorized as network_error — often self-resolves.",
+        "enabled": false
       }
     ]
   },
@@ -70,7 +78,8 @@
       {
         "code": "603",
         "label": "Decline",
-        "description": "Callee explicitly rejected the call. May still succeed at a different time."
+        "description": "Callee explicitly rejected the call. May still succeed at a different time.",
+        "enabled": false
       }
     ]
   }


### PR DESCRIPTION
## Summary

Follow-up to #483 (campaign create-page retry configuration):

While testing, we observed retry behavior that doesn't match configuration: a `maxRetries: 1` rule producing 3 actual retries. It point to the external campaign scheduler (outside this repo) — not whispey's config UI, which was verified end-to-end via simulation to send the configured values unmodified. Suspected cause: with 9 codes now spread across 5 independent retry rules (vs. the original 2 codes/2 rules), a call failing with a *different* SIP code on each attempt could match a *different* rule each time, causing per-rule retry budgets to stack instead of one shared cap per contact.

Until that's root-caused, `sip-codes.data.json` gains an `enabled` flag — only `480`/`486` are `true`. The picker now disables the other 7 codes with a "(coming soon)" label; they remain visible so the grouped UI doesn't need rebuilding once re-enabled. 