### PR TITLE
Re-enable SIP retry codes (except 408) after RCA; merge default 480/486 into one rule

### DIFF
--- a/src/app/[projectid]/campaigns/create/page.tsx
+++ b/src/app/[projectid]/campaigns/create/page.tsx
@@ -226,13 +226,7 @@ function CreateCampaign() {
     retryConfig: [
       {
         type: 'sipCode' as const,
-        errorCodes: ['480'],
-        delayMinutes: 5,
-        maxRetries: 2,
-      },
-      {
-        type: 'sipCode' as const,
-        errorCodes: ['486'],
+        errorCodes: ['480', '486'],
         delayMinutes: 5,
         maxRetries: 2,
       },

--- a/src/components/campaigns/RetryConfiguration.tsx
+++ b/src/components/campaigns/RetryConfiguration.tsx
@@ -165,9 +165,6 @@ function SipCodePicker({
                     {c.code}
                   </span>{' '}
                   <span className="font-medium text-gray-900 dark:text-gray-100">{c.label}</span>
-                  {!c.enabled && (
-                    <span className="ml-1 text-[10px] italic text-gray-400">(coming soon)</span>
-                  )}
                   <p className="text-gray-500 dark:text-gray-400">{c.description}</p>
                 </div>
               ))}
@@ -197,8 +194,7 @@ function SipCodePicker({
 
 function sipCodeButtonTitle(c: SipCode, usedElsewhere: boolean): string {
   if (c.enabled && usedElsewhere) return `${c.code} is already used in another retry rule`
-  if (c.enabled) return c.description
-  return `${c.code} — coming soon`
+  return c.description
 }
 
 function SipCodeGroup({
@@ -215,9 +211,9 @@ function SipCodeGroup({
   onSelectAll: (addable: string[]) => void
 }>) {
   const groupCodes = group.codes
-  // Only enabled, unclaimed codes can be picked up by "select all" — the
-  // rest are temporarily disabled ("Coming soon") while retry-count/backoff
-  // behavior is under RCA. Frontend-only gate; validation still accepts all.
+  // Only enabled, unclaimed codes can be picked up by "select all" — 408
+  // stays disabled pending a backend fix (configure-schedule.mjs force-
+  // overwrites its maxRetries to 3 regardless of what's configured).
   const addable = groupCodes
     .filter((c) => c.enabled && !errorCodes.includes(c.code) && !isUsedElsewhere(c.code))
     .map((c) => c.code)
@@ -257,7 +253,6 @@ function SipCodeGroup({
               }
             >
               {c.code} — {c.label}
-              {!c.enabled && <span className="ml-1 text-[10px] italic">(coming soon)</span>}
             </button>
           )
         })}

--- a/src/utils/campaigns/sip-codes.data.json
+++ b/src/utils/campaigns/sip-codes.data.json
@@ -13,7 +13,7 @@
         "code": "487",
         "label": "Request Terminated",
         "description": "Call was canceled/ended before being answered.",
-        "enabled": false
+        "enabled": true
       }
     ]
   },
@@ -31,7 +31,7 @@
         "code": "600",
         "label": "Busy Everywhere",
         "description": "Callee is busy or has do-not-disturb enabled across all their devices. May succeed once that's turned off.",
-        "enabled": false
+        "enabled": true
       }
     ]
   },
@@ -49,7 +49,7 @@
         "code": "504",
         "label": "Server Timeout",
         "description": "Upstream server took too long to respond. Same timeout bucket as 408 — usually transient.",
-        "enabled": false
+        "enabled": true
       }
     ]
   },
@@ -61,13 +61,13 @@
         "code": "500",
         "label": "Server Internal Error",
         "description": "Telephony server hit a transient internal error. Categorized as network_error — usually resolves on retry.",
-        "enabled": false
+        "enabled": true
       },
       {
         "code": "503",
         "label": "Service Unavailable",
         "description": "Telephony server is overloaded or temporarily down. Categorized as network_error — often self-resolves.",
-        "enabled": false
+        "enabled": true
       }
     ]
   },
@@ -79,7 +79,7 @@
         "code": "603",
         "label": "Decline",
         "description": "Callee explicitly rejected the call. May still succeed at a different time.",
-        "enabled": false
+        "enabled": true
       }
     ]
   }


### PR DESCRIPTION
## Summary

Follow-up to the SIP-code retry work in the create-campaign page. After root-causing why retry counts weren't matching configuration, the issue is isolated to **SIP code `408` specifically**, not the code expansion in general:

- The backend scheduling service unconditionally forces `maxRetries: 3` on any retry rule containing `408` in its `errorCodes` — silently overwriting whatever value a user configures, and injecting a hidden default rule for `408` even when it's never selected. This is a longstanding bug in that service, unrelated to whispey, confirmed against real production campaign data (both older and newer campaigns carry the identical injected rule).
- Every other SIP code (`480`, `486`, `487`, `500`, `503`, `504`, `600`, `603`) has no such hardcoded backend behavior — a user-configured rule for any of them is respected exactly as set.

Given that, this PR:

- **Re-enables 8 of the 9 SIP codes** in the retry picker (`sip-codes.data.json`: `enabled: true` for everything except `408`). `408` stays visibly disabled in the UI until the backend force-overwrite bug is fixed — kept in the data (not removed) so the grouped picker layout doesn't need rebuilding once it's safe to re-enable.
- **Drops the "(coming soon)" wording** from both the picker buttons and the info popover — disabled `408` now just shows its normal description as a tooltip, same disabled/grey styling as before.
- **Backend validation stays consistent with the picker**: `VALID_SIP_ERROR_CODE_VALUES` (shared by the Yup schema and `schedule/route.ts`) is still filtered by `enabled`, so `408` remains rejected even via a direct API call, not just blocked in the UI.
- **Merges the default retry rule**: the create-campaign page previously seeded two separate rules (one for `480`, one for `486`) on load. It now seeds a single rule covering both codes together — this removes any possibility of cross-rule "hopping" between them (a separate architectural issue found upstream, where a contact failing with different codes across attempts can accumulate more retries than any single rule specifies).

## Not in scope here (tracked separately)

- The `408` force-overwrite bug and a related dead-default bug for `500`/`503` live in the external scheduling service and require a fix there before `408` can be safely re-enabled.
- The cross-rule-hopping behavior in the scheduler's retry-matching logic is a separate, more involved fix — merging the 480/486 default rule here reduces exposure to it but doesn't eliminate it for campaigns with multiple rules.

