### PR TITLE
Local durable outbox for call exports — fix data loss and duplicate sends

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "Whispey"
-version = "4.2.8"
+version = "4.2.9"
 description = "Voice Analytics SDK for AI Agents"
 readme = "README.md"
 license = {text = "MIT"}

--- a/sdk/setup.py
+++ b/sdk/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="Whispey",
-    version="4.2.8",
+    version="4.2.9",
     author="Whispey AI Voice Analytics",
     author_email="deepesh@pypeai.com",
     description="Voice Analytics SDK for AI Agents",

--- a/sdk/tests/test_outbox_and_export_claim.py
+++ b/sdk/tests/test_outbox_and_export_claim.py
@@ -1,0 +1,274 @@
+"""
+Unit tests for the local-disk outbox + atomic export claim added to fix:
+  - data loss when a process dies before a call's data reaches Whispey
+  - duplicate sends when multiple call paths (EOD/end_call/transfer/shutdown)
+    all try to export the same call
+  - outbox entries stuck forever if a worker dies mid-drain
+  - outbox retries not happening on a day with zero new calls
+
+Run with: python3 -m unittest discover -s sdk/tests -v
+(from the repo root, or point PYTHONPATH at sdk/).
+
+stdlib unittest only, matching test_event_handlers_fallback.py's convention.
+"""
+import sys
+import os
+import time
+import asyncio
+import sqlite3
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from whispey import outbox
+from whispey.delivery_worker import drain_outbox
+from whispey import whispey as whispey_module
+
+
+class TestOutbox(unittest.TestCase):
+    """outbox.py: write -> claim -> deliver/fail, backoff, stale-claim recovery, dead-letter."""
+
+    def setUp(self):
+        self._orig_db_path = outbox._DB_PATH
+        outbox._DB_PATH = f"/tmp/whispey_outbox_test_{time.time_ns()}.db"
+
+    def tearDown(self):
+        if os.path.exists(outbox._DB_PATH):
+            os.remove(outbox._DB_PATH)
+        outbox._DB_PATH = self._orig_db_path
+
+    def test_write_then_claim_returns_entry(self):
+        entry_id = outbox.write_entry("call_1", "call_ended", {"a": 1})
+        claimed = outbox.claim_pending()
+        self.assertEqual(len(claimed), 1)
+        self.assertEqual(claimed[0]["id"], entry_id)
+        self.assertEqual(claimed[0]["payload"], {"a": 1})
+
+    def test_double_claim_while_in_progress_returns_nothing(self):
+        outbox.write_entry("call_1", "call_ended", {})
+        outbox.claim_pending()
+        self.assertEqual(outbox.claim_pending(), [])
+
+    def test_failed_entry_backs_off_before_retry(self):
+        entry_id = outbox.write_entry("call_1", "call_ended", {})
+        outbox.claim_pending()
+        outbox.mark_failed(entry_id, "network error")
+        # back to pending, but backoff hasn't elapsed yet
+        self.assertEqual(outbox.pending_count(), 1)
+        self.assertEqual(outbox.claim_pending(), [])
+
+    def test_stale_in_progress_claim_is_recovered(self):
+        entry_id = outbox.write_entry("call_1", "call_ended", {})
+        outbox.claim_pending()  # now in_progress, claimed_at = now
+
+        conn = outbox._connect()
+        conn.execute("UPDATE outbox SET claimed_at = 0 WHERE id = ?", (entry_id,))
+        conn.commit()
+        conn.close()
+
+        reclaimed = outbox.claim_pending()
+        self.assertEqual(len(reclaimed), 1)
+        self.assertEqual(reclaimed[0]["id"], entry_id)
+
+    def test_dead_lettered_after_max_attempts(self):
+        entry_id = outbox.write_entry("call_1", "call_ended", {})
+        for _ in range(outbox._MAX_ATTEMPTS):
+            outbox.claim_pending()
+            outbox.mark_failed(entry_id, "still failing")
+            conn = outbox._connect()
+            conn.execute("UPDATE outbox SET next_attempt_at = 0 WHERE id = ?", (entry_id,))
+            conn.commit()
+            conn.close()
+
+        conn = outbox._connect()
+        status = conn.execute("SELECT status FROM outbox WHERE id = ?", (entry_id,)).fetchone()[0]
+        conn.close()
+        self.assertEqual(status, "dead")
+        # dead entries are excluded from the retry queue and from pending_count
+        self.assertEqual(outbox.claim_pending(), [])
+        self.assertEqual(outbox.pending_count(), 0)
+
+    def test_mark_delivered_removes_entry(self):
+        entry_id = outbox.write_entry("call_1", "call_ended", {})
+        outbox.claim_pending()
+        outbox.mark_delivered(entry_id)
+        self.assertEqual(outbox.pending_count(), 0)
+
+    def test_write_survives_close_failure_after_commit(self):
+        """A conn.close() failure right after a successful commit must not
+        make write_entry() look like it failed — the row is already durably
+        on disk; raising here would make the caller wrongly re-send via a
+        fallback path, on top of the already-committed row. Regression test
+        for the _safe_close() fix."""
+        import unittest.mock as mock
+        real_connect = sqlite3.connect
+
+        class FlakyCloseConn:
+            def __init__(self, real_conn):
+                self._real = real_conn
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+            def close(self):
+                raise sqlite3.OperationalError("close failed, but data is already committed")
+
+        def flaky_connect(*a, **k):
+            return FlakyCloseConn(real_connect(*a, **k))
+
+        with mock.patch("sqlite3.connect", side_effect=flaky_connect):
+            entry_id = outbox.write_entry("call_1", "call_ended", {"a": 1})
+
+        self.assertIsNotNone(entry_id)
+        # the row really is there despite close() having "failed"
+        self.assertEqual(outbox.pending_count(), 1)
+
+
+class TestDeliveryWorker(unittest.IsolatedAsyncioTestCase):
+    """delivery_worker.drain_outbox(): drains claimed entries via send_fn, routes success/failure."""
+
+    def setUp(self):
+        self._orig_db_path = outbox._DB_PATH
+        outbox._DB_PATH = f"/tmp/whispey_outbox_test_{time.time_ns()}.db"
+
+    def tearDown(self):
+        if os.path.exists(outbox._DB_PATH):
+            os.remove(outbox._DB_PATH)
+        outbox._DB_PATH = self._orig_db_path
+
+    async def test_successful_send_removes_entry(self):
+        outbox.write_entry("call_1", "call_ended", {"whispey_data": {}, "apikey": "k", "api_url": "u"})
+
+        async def fake_send(data, apikey=None, api_url=None):
+            return {"success": True}
+
+        sent, failed = await drain_outbox(send_fn=fake_send)
+        self.assertEqual((sent, failed), (1, 0))
+        self.assertEqual(outbox.pending_count(), 0)
+
+    async def test_failed_send_keeps_entry_for_retry(self):
+        outbox.write_entry("call_1", "call_ended", {"whispey_data": {}, "apikey": "k", "api_url": "u"})
+
+        async def fake_send(data, apikey=None, api_url=None):
+            return {"success": False, "error": "boom"}
+
+        sent, failed = await drain_outbox(send_fn=fake_send)
+        self.assertEqual((sent, failed), (0, 1))
+        self.assertEqual(outbox.pending_count(), 1)  # still there, backing off
+
+    async def test_send_fn_exception_is_caught_and_marks_failed(self):
+        outbox.write_entry("call_1", "call_ended", {"whispey_data": {}, "apikey": "k", "api_url": "u"})
+
+        async def raising_send(data, apikey=None, api_url=None):
+            raise RuntimeError("network down")
+
+        sent, failed = await drain_outbox(send_fn=raising_send)
+        self.assertEqual((sent, failed), (0, 1))
+        self.assertEqual(outbox.pending_count(), 1)
+
+    async def test_claim_pending_error_does_not_raise(self):
+        # simulate a broken outbox file: claim_pending() will throw a
+        # sqlite error. drain_outbox() must not propagate it — a startup
+        # sweep runs fire-and-forget and must never crash the caller.
+        outbox._DB_PATH = "/nonexistent-dir/definitely/not/writable.db"
+        sent, failed = await drain_outbox(send_fn=lambda *a, **k: None)
+        self.assertEqual((sent, failed), (0, 0))
+
+
+class TestExportClaim(unittest.IsolatedAsyncioTestCase):
+    """whispey.py send_session_to_whispey(): single-writer claim + outbox-before-send."""
+
+    def setUp(self):
+        self.session_id = "sess_1"
+        whispey_module._session_data_store[self.session_id] = {
+            "call_active": True,
+            "apikey": "k",
+            "api_url": "u",
+        }
+
+        self._orig = {
+            name: getattr(whispey_module, name)
+            for name in (
+                "get_session_whispey_data",
+                "structure_telemetry_data",
+                "end_session_manually",
+                "cleanup_session",
+                "send_to_whispey",
+                "outbox_write",
+                "outbox_delivered",
+                "outbox_failed",
+            )
+        }
+        whispey_module.get_session_whispey_data = lambda sid: {"session_id": sid}
+        whispey_module.structure_telemetry_data = lambda sid: {}
+        whispey_module.end_session_manually = lambda *a, **k: None
+        whispey_module.cleanup_session = lambda sid: whispey_module._session_data_store.pop(sid, None)
+
+        self.send_calls = []
+
+        async def fake_send(data, apikey=None, api_url=None):
+            self.send_calls.append(data)
+            return {"success": True}
+
+        whispey_module.send_to_whispey = fake_send
+        whispey_module.outbox_write = lambda call_id, event_type, payload: 1
+        whispey_module.outbox_delivered = lambda entry_id: None
+        whispey_module.outbox_failed = lambda entry_id, error: None
+
+    def tearDown(self):
+        whispey_module._session_data_store.pop(self.session_id, None)
+        for name, fn in self._orig.items():
+            setattr(whispey_module, name, fn)
+
+    async def test_first_call_sends_second_call_skips(self):
+        whispey_module._session_data_store[self.session_id]["call_active"] = True
+        first = await whispey_module.send_session_to_whispey(self.session_id)
+        self.assertTrue(first.get("success"))
+        self.assertNotIn("skipped", first)
+        self.assertEqual(len(self.send_calls), 1)
+
+        # session was cleaned up after success — simulate a second trigger
+        # path racing in with its own leftover reference to the session dict
+        # (this is what _export_claimed is actually guarding against: the
+        # dict entry existing but already claimed, not a missing session).
+        whispey_module._session_data_store[self.session_id] = {
+            "call_active": True, "apikey": "k", "api_url": "u", "_export_claimed": True,
+        }
+        second = await whispey_module.send_session_to_whispey(self.session_id)
+        self.assertEqual(second, {"success": True, "skipped": True})
+        self.assertEqual(len(self.send_calls), 1)  # still just the one real send
+
+    async def test_outbox_write_failure_falls_back_to_direct_send(self):
+        def raising_write(*a, **k):
+            raise OSError("disk full")
+        whispey_module.outbox_write = raising_write
+
+        result = await whispey_module.send_session_to_whispey(self.session_id)
+        self.assertTrue(result.get("success"))
+        self.assertEqual(len(self.send_calls), 1)  # fell back to a direct send
+        # success cleans up the session — nothing left to leak or re-claim
+        self.assertNotIn(self.session_id, whispey_module._session_data_store)
+
+    async def test_outbox_write_and_direct_send_both_failing_clears_claim(self):
+        def raising_write(*a, **k):
+            raise OSError("disk full")
+        async def raising_send(data, apikey=None, api_url=None):
+            raise ConnectionError("network unreachable")
+        whispey_module.outbox_write = raising_write
+        whispey_module.send_to_whispey = raising_send
+
+        result = await whispey_module.send_session_to_whispey(self.session_id)
+        self.assertFalse(result.get("success"))
+        # claim must be released — otherwise this call could never be retried
+        self.assertFalse(whispey_module._session_data_store[self.session_id]["_export_claimed"])
+
+    async def test_send_failure_keeps_claim_so_outbox_owns_retry(self):
+        async def failing_send(data, apikey=None, api_url=None):
+            return {"success": False, "error": "5xx"}
+        whispey_module.send_to_whispey = failing_send
+
+        result = await whispey_module.send_session_to_whispey(self.session_id)
+        self.assertFalse(result.get("success"))
+        self.assertTrue(whispey_module._session_data_store[self.session_id]["_export_claimed"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/whispey/delivery_worker.py
+++ b/sdk/whispey/delivery_worker.py
@@ -1,0 +1,79 @@
+"""Drains the local outbox and delivers entries to Whispey.
+
+Independent of any specific call's process — safe to run from a fresh
+process on startup (sweeps up anything a prior process left behind), or
+from a periodic scheduled job.
+"""
+
+import logging
+
+from whispey.outbox import claim_pending, mark_delivered, mark_failed
+from whispey.send_log import send_to_whispey
+
+logger = logging.getLogger("whispey_outbox")
+
+
+async def drain_outbox(limit: int = 10, send_fn=send_to_whispey):
+    """Claim up to `limit` pending entries and attempt delivery. Returns (sent, failed) counts."""
+    try:
+        entries = claim_pending(limit=limit)
+    except Exception as e:
+        logger.error(f"[OUTBOX] claim_pending failed, skipping this drain: {e}")
+        return 0, 0
+    if not entries:
+        return 0, 0
+
+    sent, failed = 0, 0
+    for entry in entries:
+        entry_id = entry["id"]
+        call_id = entry["call_id"]
+        body = entry["payload"]
+        try:
+            result = await send_fn(
+                body["whispey_data"],
+                apikey=body.get("apikey"),
+                api_url=body.get("api_url"),
+            )
+            if result.get("success"):
+                mark_delivered(entry_id)
+                sent += 1
+            else:
+                mark_failed(entry_id, str(result))
+                failed += 1
+        except Exception as e:
+            logger.error(f"[OUTBOX] delivery worker error for call_id={call_id} id={entry_id}: {e}")
+            mark_failed(entry_id, str(e))
+            failed += 1
+
+    logger.info(f"[OUTBOX] drain complete: sent={sent} failed={failed}")
+    return sent, failed
+
+
+async def _demo():
+    import os
+    from whispey import outbox as outbox_module
+
+    outbox_module._DB_PATH = "/tmp/whispey_delivery_demo.db"
+    if os.path.exists(outbox_module._DB_PATH):
+        os.remove(outbox_module._DB_PATH)
+
+    outbox_module.write_entry("call_1", "call_ended", {
+        "whispey_data": {"call_id": "call_1"}, "apikey": "k", "api_url": "u",
+    })
+
+    async def fake_send(data, apikey=None, api_url=None):
+        assert data["call_id"] == "call_1"
+        assert apikey == "k" and api_url == "u"
+        return {"success": True}
+
+    sent, failed = await drain_outbox(send_fn=fake_send)
+    assert sent == 1 and failed == 0
+    assert outbox_module.pending_count() == 0
+
+    os.remove(outbox_module._DB_PATH)
+    print("delivery_worker self-check passed")
+
+
+if __name__ == "__main__":
+    import asyncio
+    asyncio.run(_demo())

--- a/sdk/whispey/outbox.py
+++ b/sdk/whispey/outbox.py
@@ -1,0 +1,193 @@
+"""Local durable outbox for call events (call_started / call_ended / recording_ready).
+
+Write is fast and local so it can't be interrupted by process shutdown.
+A separate delivery worker (not in this file) drains it and does the
+actual network send, with retries.
+"""
+
+import json
+import logging
+import os
+import random
+import sqlite3
+import time
+
+logger = logging.getLogger("whispey_outbox")
+
+_DB_PATH = os.environ.get("WHISPEY_OUTBOX_PATH", "/tmp/whispey_outbox.db")
+_MAX_ATTEMPTS = 10
+_MAX_BACKOFF_SECONDS = 300
+_STALE_CLAIM_SECONDS = 300  # a claim this old is treated as abandoned
+
+
+def _backoff_seconds(attempts: int) -> float:
+    base = min(2 ** attempts, _MAX_BACKOFF_SECONDS)
+    return base + random.uniform(0, base * 0.2)  # jitter
+
+
+def _safe_close(conn):
+    """conn.close() can itself raise. If it does after a commit already
+    succeeded, letting it propagate from a `finally` would discard the
+    result and make an already-durable write look like it failed —
+    triggering a needless (and duplicate-risking) fallback upstream."""
+    try:
+        conn.close()
+    except Exception as e:
+        logger.warning(f"[OUTBOX] connection close failed (write/commit already done): {e}")
+
+
+def _connect():
+    conn = sqlite3.connect(_DB_PATH, timeout=5)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS outbox (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            call_id TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            payload TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'pending',
+            attempts INTEGER NOT NULL DEFAULT 0,
+            created_at REAL NOT NULL,
+            next_attempt_at REAL NOT NULL DEFAULT 0,
+            claimed_at REAL,
+            last_error TEXT
+        )
+        """
+    )
+    return conn
+
+
+def write_entry(call_id: str, event_type: str, payload: dict) -> int:
+    """Fast, durable write. Call this before anything risky (network, shutdown)."""
+    conn = _connect()
+    try:
+        now = time.time()
+        cur = conn.execute(
+            "INSERT INTO outbox (call_id, event_type, payload, created_at, next_attempt_at) VALUES (?, ?, ?, ?, ?)",
+            (call_id, event_type, json.dumps(payload), now, now),
+        )
+        conn.commit()
+        logger.info(f"[OUTBOX] wrote entry id={cur.lastrowid} call_id={call_id} event={event_type}")
+        return cur.lastrowid
+    finally:
+        _safe_close(conn)
+
+
+def claim_pending(limit: int = 10):
+    """Atomically claim up to `limit` entries for delivery: pending ones whose
+    backoff has elapsed, plus in_progress ones abandoned by a worker that
+    died mid-drain (claimed longer than _STALE_CLAIM_SECONDS ago)."""
+    conn = _connect()
+    try:
+        now = time.time()
+        conn.execute("BEGIN IMMEDIATE")
+        rows = conn.execute(
+            "SELECT id, call_id, event_type, payload, attempts FROM outbox "
+            "WHERE (status = 'pending' AND next_attempt_at <= ?) "
+            "   OR (status = 'in_progress' AND claimed_at <= ?) "
+            "ORDER BY created_at LIMIT ?",
+            (now, now - _STALE_CLAIM_SECONDS, limit),
+        ).fetchall()
+        ids = [r[0] for r in rows]
+        if ids:
+            conn.executemany(
+                "UPDATE outbox SET status = 'in_progress', claimed_at = ? WHERE id = ?",
+                [(now, i) for i in ids],
+            )
+        conn.commit()
+        if ids:
+            logger.info(f"[OUTBOX] claimed {len(ids)} entr(ies): ids={ids}")
+        return [
+            {"id": r[0], "call_id": r[1], "event_type": r[2], "payload": json.loads(r[3]), "attempts": r[4]}
+            for r in rows
+        ]
+    finally:
+        _safe_close(conn)
+
+
+def mark_delivered(entry_id: int):
+    conn = _connect()
+    try:
+        conn.execute("DELETE FROM outbox WHERE id = ?", (entry_id,))
+        conn.commit()
+        logger.info(f"[OUTBOX] delivered id={entry_id}")
+    finally:
+        _safe_close(conn)
+
+
+def mark_failed(entry_id: int, error: str):
+    """Bump attempts and reset to pending for retry, or dead-letter past the cap."""
+    conn = _connect()
+    try:
+        row = conn.execute("SELECT attempts FROM outbox WHERE id = ?", (entry_id,)).fetchone()
+        if row is None:
+            return
+        attempts = row[0] + 1
+        status = "dead" if attempts >= _MAX_ATTEMPTS else "pending"
+        next_attempt_at = time.time() + _backoff_seconds(attempts)
+        conn.execute(
+            "UPDATE outbox SET status = ?, attempts = ?, last_error = ?, next_attempt_at = ? WHERE id = ?",
+            (status, attempts, error, next_attempt_at, entry_id),
+        )
+        conn.commit()
+        if status == "dead":
+            logger.error(f"[OUTBOX] id={entry_id} DEAD-LETTERED after {attempts} attempts: {error}")
+        else:
+            logger.warning(f"[OUTBOX] id={entry_id} failed (attempt {attempts}), retry in {_backoff_seconds(attempts):.0f}s: {error}")
+    finally:
+        _safe_close(conn)
+
+
+def pending_count() -> int:
+    conn = _connect()
+    try:
+        return conn.execute("SELECT COUNT(*) FROM outbox WHERE status != 'dead'").fetchone()[0]
+    finally:
+        _safe_close(conn)
+
+
+def _demo():
+    global _DB_PATH
+    _DB_PATH = "/tmp/whispey_outbox_demo.db"
+    if os.path.exists(_DB_PATH):
+        os.remove(_DB_PATH)
+
+    entry_id = write_entry("call_123", "call_ended", {"transcript": "hello"})
+    assert pending_count() == 1
+
+    claimed = claim_pending()
+    assert len(claimed) == 1 and claimed[0]["id"] == entry_id
+
+    # a second claim while still in_progress should find nothing
+    assert claim_pending() == []
+
+    mark_failed(entry_id, "simulated network error")
+    assert pending_count() == 1  # back to pending, retryable
+    assert claim_pending() == []  # backoff not elapsed yet — must not claim early
+
+    conn = _connect()
+    conn.execute("UPDATE outbox SET next_attempt_at = 0 WHERE id = ?", (entry_id,))
+    conn.commit()
+    conn.close()
+
+    claimed = claim_pending()
+    entry_id2 = claimed[0]["id"]
+
+    # simulate a worker dying mid-drain: claimed but never resolved
+    conn = _connect()
+    conn.execute("UPDATE outbox SET claimed_at = 0 WHERE id = ?", (entry_id2,))
+    conn.commit()
+    conn.close()
+    reclaimed = claim_pending()
+    assert len(reclaimed) == 1 and reclaimed[0]["id"] == entry_id2  # stale claim recovered
+
+    mark_delivered(entry_id2)
+    assert pending_count() == 0
+
+    os.remove(_DB_PATH)
+    print("outbox self-check passed")
+
+
+if __name__ == "__main__":
+    _demo()

--- a/sdk/whispey/whispey.py
+++ b/sdk/whispey/whispey.py
@@ -6,7 +6,8 @@ from datetime import datetime
 from typing import Dict, Any
 from whispey.event_handlers import setup_session_event_handlers, safe_extract_transcript_data
 from whispey.metrics_service import setup_usage_collector, create_session_data
-from whispey.send_log import send_to_whispey, send_to_whispey_sync
+from whispey.send_log import send_to_whispey
+from whispey.outbox import write_entry as outbox_write, mark_delivered as outbox_delivered, mark_failed as outbox_failed
 
 logger = logging.getLogger("observe_session")
 
@@ -37,24 +38,42 @@ def _sync_flush_all_sessions():
     session_ids = list(_session_data_store.keys())
     if not session_ids:
         return
-    logger.info(f"🚨 SDK exit flush: sending {len(session_ids)} pending session(s) synchronously")
+    logger.info(f"🚨 SDK exit flush: checking {len(session_ids)} pending session(s)")
     for session_id in session_ids:
         try:
+            session_info = _session_data_store.get(session_id)
+            if session_info is None:
+                continue  # cleaned up between the keys() snapshot and now
+
+            # Same atomic claim as send_session_to_whispey(): if an async
+            # export for this session is already in flight (or already
+            # succeeded), don't also fire a second, independent send from
+            # here — this is the exact gap that used to let this fallback
+            # bypass the guard entirely and duplicate-send.
+            if session_info.get('_export_claimed'):
+                logger.info(f"⏭️ Exit flush: {session_id} already claimed by another export path — skipping")
+                continue
+            session_info['_export_claimed'] = True
+
             end_session_manually(session_id, "process_exit")
             # Use the cached/finalized data (correct recording_url, real transcript)
             # if it already exists — session_data may have been wiped by the caller's
             # own cleanup by the time this atexit flush runs, which would make a
-            # fresh generate_whispey_data() call return an empty, URL-less payload
-            # that overwrites a real send still in flight when the process exited.
+            # fresh generate_whispey_data() call return an empty, URL-less payload.
             data = get_session_whispey_data(session_id)
-            apikey = _session_data_store.get(session_id, {}).get("apikey")
-            api_url = _session_data_store.get(session_id, {}).get("api_url")
-            result = send_to_whispey_sync(data, apikey=apikey, api_url=api_url)
-            if result.get("success"):
-                logger.info(f"✅ Exit flush: sent session {session_id}")
-                cleanup_session(session_id)
-            else:
-                logger.error(f"❌ Exit flush: failed for {session_id}: {result}")
+            apikey = session_info.get("apikey")
+            api_url = session_info.get("api_url")
+
+            # No network call here — a dying process can't reliably complete
+            # one. Just make sure this call's data is durably saved; the
+            # delivery worker sends it later, with retries and S3 support.
+            outbox_write(session_id, "call_ended", {
+                "whispey_data": data,
+                "apikey": apikey,
+                "api_url": api_url,
+            })
+            logger.info(f"[OUTBOX] exit flush: saved session {session_id} for later delivery")
+            cleanup_session(session_id)
         except Exception as e:
             logger.error(f"❌ Exit flush error for {session_id}: {e}")
 
@@ -1016,8 +1035,21 @@ async def send_session_to_whispey(session_id: str, recording_url: str = "", addi
     if session_id not in _session_data_store:
         logger.error(f"Session {session_id} not found in data store")
         return {"success": False, "error": "Session not found"}
-    
+
     session_info = _session_data_store[session_id]
+
+    # Atomic claim: multiple independent call paths (transfer, EOD, generic
+    # shutdown, end_call tool, and the atexit/SIGTERM fallback in
+    # _sync_flush_all_sessions) can all reach this function for the same
+    # session. Checked+set synchronously, before any await, so a
+    # concurrent/later caller sees it immediately and skips instead of
+    # re-sending the same data. Cleared on failure so a genuinely failed
+    # send can still be retried by a later caller.
+    if session_info.get('_export_claimed'):
+        logger.info(f"⏭️ Export already claimed for {session_id} — skipping duplicate call")
+        return {"success": True, "skipped": True}
+    session_info['_export_claimed'] = True
+
     # Use session-stored apikey/api_url if not passed (same as call_started)
     apikey = apikey if apikey is not None else session_info.get("apikey")
     api_url = api_url if api_url is not None else session_info.get("api_url")
@@ -1050,21 +1082,64 @@ async def send_session_to_whispey(session_id: str, recording_url: str = "", addi
     
     
     try:
-        logger.info(f"📤 Sending to Whispey API...")
-        result = await send_to_whispey(whispey_data, apikey=apikey, api_url=api_url)
-        
+        outbox_id = outbox_write(session_id, "call_ended", {
+            "whispey_data": whispey_data,
+            "apikey": apikey,
+            "api_url": api_url,
+        })
+        logger.info(f"[OUTBOX] session {session_id} saved locally as id={outbox_id} before send")
+    except Exception as e:
+        # Outbox write itself failed — no durable copy exists, so there's
+        # nothing for a delivery worker to retry later. Attempt the send
+        # directly, right now, as a last resort instead of giving up.
+        logger.error(f"❌ Outbox write failed for {session_id}: {e} — attempting direct send as fallback")
+        try:
+            result = await send_to_whispey(whispey_data, apikey=apikey, api_url=api_url)
+        except Exception as send_e:
+            # Both the durable write and the direct send failed — this call's
+            # data is genuinely at risk of being lost. Log at CRITICAL,
+            # distinct from the routine errors above, so it can be alerted
+            # on separately. Clear the claim so a later trigger (e.g. the
+            # atexit fallback) still gets a chance to try again.
+            logger.critical(
+                f"🚨 [DATA LOSS RISK] Outbox write AND direct send both failed for {session_id}: "
+                f"outbox={e}, send={send_e}"
+            )
+            session_info['_export_claimed'] = False
+            return {"success": False, "error": f"outbox write failed ({e}); direct send also failed ({send_e})"}
+
         if result.get("success"):
-            logger.info(f"✅ Successfully sent session {session_id} to Whispey")
+            logger.info(f"✅ Direct send succeeded for {session_id} despite outbox failure")
             cleanup_session(session_id)
         else:
-            logger.error(f"❌ Whispey API returned failure: {result}")
-        
+            logger.error(f"❌ Direct send also returned failure for {session_id}: {result}")
+            session_info['_export_claimed'] = False
         return result
-        
+
+    try:
+        logger.info(f"📤 Sending to Whispey API...")
+        result = await send_to_whispey(whispey_data, apikey=apikey, api_url=api_url)
+
+        if result.get("success"):
+            logger.info(f"✅ Successfully sent session {session_id} to Whispey")
+            outbox_delivered(outbox_id)
+            cleanup_session(session_id)
+        else:
+            # Don't clear _export_claimed here: the outbox entry (marked
+            # failed below) already owns retrying this send, on its own
+            # backoff schedule. Clearing the claim would let a different
+            # trigger path (e.g. the generic exporter) write a second,
+            # duplicate outbox entry for this same call.
+            logger.error(f"❌ Whispey API returned failure: {result}")
+            outbox_failed(outbox_id, str(result))
+
+        return result
+
     except Exception as e:
         logger.error(f"❌ Exception sending to Whispey: {e}")
         import traceback
         traceback.print_exc()
+        outbox_failed(outbox_id, str(e))
         return {"success": False, "error": str(e)}
 
 


### PR DESCRIPTION
Added a local SQLite outbox (outbox.py): every call's data is written to disk before the network send, with exponential backoff + dead-letter after 10 attempts, and stale-claim recovery if a worker dies mid-drain.
Added delivery_worker.drain_outbox() to retry undelivered entries.
Added an atomic _export_claimed guard in send_session_to_whispey() so the multiple trigger paths (EOD, end_call, transfer, shutdown callback, atexit/SIGTERM fallback) can never double-send the same call — fixes duplicate transcript rows.
Hardened the outbox write path: if the durable write itself fails, falls back to a direct send instead of losing data; if a connection-close error happens right after a successful commit, it no longer masks the write as failed (was a latent double-send risk).