### PR TITLE
Feat/Add voicemail_detection tool config UI and fix serialization data loss

### DIFF
--- a/__tests__/hooks/useAgentConfig.test.ts
+++ b/__tests__/hooks/useAgentConfig.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { deserializeToolConfig, getDefaultToolName } from '@/hooks/useAgentConfig'
+
+describe('getDefaultToolName', () => {
+  it('returns the mapped display name for voicemail_detection', () => {
+    // Regression test: this entry was missing from DEFAULT_TOOL_NAMES, which
+    // caused the tool's display name to fall back to "Custom Tool" after an
+    // agent update instead of showing "Voicemail Detection".
+    expect(getDefaultToolName('voicemail_detection')).toBe('Voicemail Detection')
+  })
+
+  it('falls back to "Custom Tool" for an unmapped type', () => {
+    expect(getDefaultToolName('some_unknown_tool_type')).toBe('Custom Tool')
+  })
+})
+
+describe('deserializeToolConfig — voicemail_detection fields', () => {
+  it('reads vm_message and vm_wait_timeout back from the saved tool', () => {
+    const tool = { vm_message: 'Please call back soon', vm_wait_timeout: 10 }
+    const result = deserializeToolConfig(tool)
+    expect(result.vm_message).toBe('Please call back soon')
+    expect(result.vm_wait_timeout).toBe(10)
+  })
+
+  it('falls back to real defaults when the fields are missing entirely', () => {
+    const result = deserializeToolConfig({})
+    expect(result.vm_message).toMatch(/reached a voicemail/)
+    expect(result.vm_wait_timeout).toBe(7)
+  })
+
+  it('preserves a blank saved vm_message instead of reverting to the default (?? not ||)', () => {
+    const tool = { vm_message: '', vm_wait_timeout: 10 }
+    const result = deserializeToolConfig(tool)
+    expect(result.vm_message).toBe('')
+  })
+
+  it('preserves a saved 0 vm_wait_timeout instead of reverting to the default (?? not ||)', () => {
+    const tool = { vm_message: 'Bye', vm_wait_timeout: 0 }
+    const result = deserializeToolConfig(tool)
+    expect(result.vm_wait_timeout).toBe(0)
+  })
+})

--- a/__tests__/hooks/useMultiAssistantState.test.ts
+++ b/__tests__/hooks/useMultiAssistantState.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { buildAgentEnvelope } from '@/hooks/useMultiAssistantState'
+import {
+  buildAgentEnvelope,
+  serializeVoicemailDetectionTool,
+  serializeAssistantToolFull,
+  serializeAssistantToolBasic,
+} from '@/hooks/useMultiAssistantState'
 
 describe('buildAgentEnvelope', () => {
   it('includes agent_id when provided', () => {
@@ -21,5 +26,81 @@ describe('buildAgentEnvelope', () => {
     const assistants = [{ prompt: 'a' }, { prompt: 'b' }]
     const result = buildAgentEnvelope('Agent', 'pipecat', assistants)
     expect(result.agent.assistant).toHaveLength(2)
+  })
+})
+
+describe('serializeVoicemailDetectionTool', () => {
+  const baseToolConfig = { type: 'voicemail_detection' }
+  const commonFields = { name: 'Voicemail Detection', description: 'Detects voicemail' }
+
+  it('includes vm_message and vm_wait_timeout from tool.config', () => {
+    const tool = { config: { vm_message: 'Call back later', vm_wait_timeout: 12 } }
+    const result = serializeVoicemailDetectionTool(tool, baseToolConfig, commonFields)
+    expect(result).toEqual({
+      type: 'voicemail_detection',
+      name: 'Voicemail Detection',
+      description: 'Detects voicemail',
+      vm_message: 'Call back later',
+      vm_wait_timeout: 12,
+    })
+  })
+
+  it('falls back to real defaults when config fields are absent', () => {
+    const tool = { config: {} }
+    const result = serializeVoicemailDetectionTool(tool, baseToolConfig, commonFields)
+    expect(result.vm_message).toMatch(/reached a voicemail/)
+    expect(result.vm_wait_timeout).toBe(7)
+  })
+
+  it('preserves a blank vm_message instead of falling back to the default (?? not ||)', () => {
+    const tool = { config: { vm_message: '', vm_wait_timeout: 12 } }
+    const result = serializeVoicemailDetectionTool(tool, baseToolConfig, commonFields)
+    expect(result.vm_message).toBe('')
+  })
+
+  it('preserves a 0 vm_wait_timeout instead of falling back to the default (?? not ||)', () => {
+    const tool = { config: { vm_message: 'Bye', vm_wait_timeout: 0 } }
+    const result = serializeVoicemailDetectionTool(tool, baseToolConfig, commonFields)
+    expect(result.vm_wait_timeout).toBe(0)
+  })
+})
+
+describe('serializeAssistantToolFull / serializeAssistantToolBasic — voicemail_detection', () => {
+  // Regression test: these dispatchers had no case for voicemail_detection at
+  // all, so saving silently reduced it to just {type: 'voicemail_detection'},
+  // dropping name/description/vm_message/vm_wait_timeout on every agent update.
+  const tool = {
+    type: 'voicemail_detection',
+    name: 'Voicemail Detection',
+    config: { description: 'Detects voicemail', vm_message: 'Please call back', vm_wait_timeout: 5 },
+  }
+
+  it('serializeAssistantToolFull preserves the full voicemail_detection config', () => {
+    const result = serializeAssistantToolFull(tool)
+    expect(result).toEqual({
+      type: 'voicemail_detection',
+      name: 'Voicemail Detection',
+      description: 'Detects voicemail',
+      vm_message: 'Please call back',
+      vm_wait_timeout: 5,
+    })
+  })
+
+  it('serializeAssistantToolBasic preserves the full voicemail_detection config', () => {
+    const result = serializeAssistantToolBasic(tool)
+    expect(result).toEqual({
+      type: 'voicemail_detection',
+      name: 'Voicemail Detection',
+      description: 'Detects voicemail',
+      vm_message: 'Please call back',
+      vm_wait_timeout: 5,
+    })
+  })
+
+  it('does not reduce to just {type} the way the unfixed fallthrough did', () => {
+    const result = serializeAssistantToolFull(tool)
+    expect(Object.keys(result).sort()).not.toEqual(['type'])
+    expect(result).toHaveProperty('vm_message')
+    expect(result).toHaveProperty('vm_wait_timeout')
   })
 })

--- a/src/app/api/agents/save-and-deploy/route.ts
+++ b/src/app/api/agents/save-and-deploy/route.ts
@@ -324,6 +324,10 @@ function serializeRouteTool(tool: any): any {
         //   enable_as_tag  defaults to false (new <transfer/> tag trigger)
         enable_as_tool: tool.config.enableAsTool !== false,
         enable_as_tag: tool.config.enableAsTag === true,
+      } : tool.type === 'voicemail_detection' ? {
+        // ?? not || - a blank message / 0 timeout is an intentional config (instant, silent hangup).
+        vm_message: tool.config.vm_message ?? "It looks like I've reached a voicemail. Please call us back when you're available. Thank you, goodbye.",
+        vm_wait_timeout: tool.config.vm_wait_timeout ?? 7,
       } : {})
     } : {})
   }

--- a/src/app/api/agents/save-and-deploy/route.ts
+++ b/src/app/api/agents/save-and-deploy/route.ts
@@ -300,37 +300,53 @@ function serializeRouteTts(ttsConfiguration: any): any {
 }
 
 function serializeRouteTool(tool: any): any {
-  return {
-    type: tool.type,
-    ...(tool.type !== 'end_call' ? {
-      name: tool.name,
-      description: tool.config.description,
-      ...(tool.type === 'custom_function' ? {
-        api_url: tool.config.endpoint,
-        http_method: tool.config.method,
-        timeout: tool.config.timeout,
-        async: tool.config.asyncExecution,
-        headers: tool.config.headers,
-        parameters: tool.config.parameters,
-        filler_config: tool.config.filler_config ?? null,
-      } : tool.type === 'transfer_call' ? {
-        transfer_number: tool.config.transferNumber,
-        sip_outbound_trunk: tool.config.sipTrunkId,
-        acefone_token: tool.config.acefoneToken || null,
-        pre_transfer_webhook_url: tool.config.preTransferWebhookUrl || null,
-        pre_transfer_webhook_fields: tool.config.preTransferWebhookFields || null,
-        // Trigger-mode flags. Defaults preserve old behavior:
-        //   enable_as_tool defaults to true  (current tool-based trigger)
-        //   enable_as_tag  defaults to false (new <transfer/> tag trigger)
-        enable_as_tool: tool.config.enableAsTool !== false,
-        enable_as_tag: tool.config.enableAsTag === true,
-      } : tool.type === 'voicemail_detection' ? {
-        // ?? not || - a blank message / 0 timeout is an intentional config (instant, silent hangup).
-        vm_message: tool.config.vm_message ?? "It looks like I've reached a voicemail. Please call us back when you're available. Thank you, goodbye.",
-        vm_wait_timeout: tool.config.vm_wait_timeout ?? 7,
-      } : {})
-    } : {})
+  const baseToolConfig = { type: tool.type }
+  if (tool.type === 'end_call') return baseToolConfig
+
+  const commonFields = { name: tool.name, description: tool.config.description }
+
+  if (tool.type === 'custom_function') {
+    return {
+      ...baseToolConfig,
+      ...commonFields,
+      api_url: tool.config.endpoint,
+      http_method: tool.config.method,
+      timeout: tool.config.timeout,
+      async: tool.config.asyncExecution,
+      headers: tool.config.headers,
+      parameters: tool.config.parameters,
+      filler_config: tool.config.filler_config ?? null,
+    }
   }
+
+  if (tool.type === 'transfer_call') {
+    return {
+      ...baseToolConfig,
+      ...commonFields,
+      transfer_number: tool.config.transferNumber,
+      sip_outbound_trunk: tool.config.sipTrunkId,
+      acefone_token: tool.config.acefoneToken || null,
+      pre_transfer_webhook_url: tool.config.preTransferWebhookUrl || null,
+      pre_transfer_webhook_fields: tool.config.preTransferWebhookFields || null,
+      // Trigger-mode flags. Defaults preserve old behavior:
+      //   enable_as_tool defaults to true  (current tool-based trigger)
+      //   enable_as_tag  defaults to false (new <transfer/> tag trigger)
+      enable_as_tool: tool.config.enableAsTool !== false,
+      enable_as_tag: tool.config.enableAsTag === true,
+    }
+  }
+
+  if (tool.type === 'voicemail_detection') {
+    return {
+      ...baseToolConfig,
+      ...commonFields,
+      // ?? not || - a blank message / 0 timeout is an intentional config (instant, silent hangup).
+      vm_message: tool.config.vm_message ?? "It looks like I've reached a voicemail. Please call us back when you're available. Thank you, goodbye.",
+      vm_wait_timeout: tool.config.vm_wait_timeout ?? 7,
+    }
+  }
+
+  return { ...baseToolConfig, ...commonFields }
 }
 
 function serializeRouteLanguageSwitchTool(ls: any): any {

--- a/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/ToolsActionsSettingsProps.tsx
+++ b/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/ToolsActionsSettingsProps.tsx
@@ -112,6 +112,10 @@ interface Tool {
     max_results?: number
     hospitals_json?: string
     areas_json?: string
+    // Voicemail detection fields (spoken via session.say(), not the LLM — so an
+    // empty message is valid and means "don't speak anything, just wait/hang up")
+    vm_message?: string
+    vm_wait_timeout?: number
     // Tool call filler words (custom_function only)
     filler_config?: FillerConfig
   }
@@ -173,6 +177,9 @@ function ToolsActionsSettings({ tools, languageSwitchTools = [], turnDetection, 
     max_results: 3,
     hospitals_json: '[]',
     areas_json: '{}',
+    // Voicemail detection fields
+    vm_message: '',
+    vm_wait_timeout: 0,
     // Filler words
     filler_config: { ...DEFAULT_FILLER_CONFIG } as FillerConfig,
   })
@@ -253,6 +260,8 @@ function ToolsActionsSettings({ tools, languageSwitchTools = [], turnDetection, 
         max_results: 3,
         hospitals_json: '[]',
         areas_json: '{}',
+        vm_message: '',
+        vm_wait_timeout: 0,
         filler_config: { ...DEFAULT_FILLER_CONFIG },
       })
     } else if (toolType === 'handoff') {
@@ -288,6 +297,8 @@ function ToolsActionsSettings({ tools, languageSwitchTools = [], turnDetection, 
         max_results: 3,
         hospitals_json: '[]',
         areas_json: '{}',
+        vm_message: '',
+        vm_wait_timeout: 0,
         filler_config: { ...DEFAULT_FILLER_CONFIG },
       })
     } else if (toolType === 'transfer_call') {
@@ -323,6 +334,8 @@ function ToolsActionsSettings({ tools, languageSwitchTools = [], turnDetection, 
         max_results: 3,
         hospitals_json: '[]',
         areas_json: '{}',
+        vm_message: '',
+        vm_wait_timeout: 0,
         filler_config: { ...DEFAULT_FILLER_CONFIG },
       })
     } else if (toolType === 'ivr_navigator') {
@@ -358,6 +371,8 @@ function ToolsActionsSettings({ tools, languageSwitchTools = [], turnDetection, 
         max_results: 3,
         hospitals_json: '[]',
         areas_json: '{}',
+        vm_message: '',
+        vm_wait_timeout: 0,
         filler_config: { ...DEFAULT_FILLER_CONFIG },
       })
     } else if (toolType === 'nearby_location_finder') {
@@ -393,6 +408,8 @@ function ToolsActionsSettings({ tools, languageSwitchTools = [], turnDetection, 
         max_results: 3,
         hospitals_json: '[]',
         areas_json: '{}',
+        vm_message: '',
+        vm_wait_timeout: 0,
         filler_config: { ...DEFAULT_FILLER_CONFIG },
       })
     } else if (toolType === 'update_vad_options') {
@@ -428,6 +445,8 @@ function ToolsActionsSettings({ tools, languageSwitchTools = [], turnDetection, 
         max_results: 3,
         hospitals_json: '[]',
         areas_json: '{}',
+        vm_message: '',
+        vm_wait_timeout: 0,
         filler_config: { ...DEFAULT_FILLER_CONFIG },
       })
     } else if (toolType === 'voicemail_detection') {
@@ -463,6 +482,8 @@ function ToolsActionsSettings({ tools, languageSwitchTools = [], turnDetection, 
         max_results: 3,
         hospitals_json: '[]',
         areas_json: '{}',
+        vm_message: "It looks like I've reached a voicemail. Please call us back when you're available. Thank you, goodbye.",
+        vm_wait_timeout: 7,
         filler_config: { ...DEFAULT_FILLER_CONFIG },
       })
     } else {
@@ -498,6 +519,8 @@ function ToolsActionsSettings({ tools, languageSwitchTools = [], turnDetection, 
         max_results: 3,
         hospitals_json: '[]',
         areas_json: '{}',
+        vm_message: '',
+        vm_wait_timeout: 0,
         filler_config: { ...DEFAULT_FILLER_CONFIG },
       })
     }
@@ -552,6 +575,11 @@ function ToolsActionsSettings({ tools, languageSwitchTools = [], turnDetection, 
       max_results: tool.config.max_results ?? 3,
       hospitals_json: tool.config.hospitals_json ?? '[]',
       areas_json: tool.config.areas_json ?? '{}',
+      // ?? (not ||) — a deliberately blank message or 0 timeout is a valid,
+      // intentional value (means "stay silent" / "hang up instantly") and must
+      // not be overwritten by the default when re-opening this tool to edit it.
+      vm_message: tool.config.vm_message ?? "It looks like I've reached a voicemail. Please call us back when you're available. Thank you, goodbye.",
+      vm_wait_timeout: tool.config.vm_wait_timeout ?? 7,
       filler_config: { ...DEFAULT_FILLER_CONFIG, ...(tool.config.filler_config ?? {}) },
     })
     setNewFillerMessage('')
@@ -618,6 +646,10 @@ function ToolsActionsSettings({ tools, languageSwitchTools = [], turnDetection, 
           max_results: formData.max_results,
           hospitals_json: formData.hospitals_json,
           areas_json: formData.areas_json
+        }),
+        ...(selectedToolType === 'voicemail_detection' && {
+          vm_message: formData.vm_message,
+          vm_wait_timeout: formData.vm_wait_timeout
         }),
         ...(selectedToolType === 'custom_function' && {
           filler_config: formData.filler_config,
@@ -1550,6 +1582,40 @@ function ToolsActionsSettings({ tools, languageSwitchTools = [], turnDetection, 
                   />
                   <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
                     Keys should be lowercase area names. Values are [lat, lng].
+                  </p>
+                </div>
+              </>
+            )}
+
+            {/* Voicemail Detection specific fields */}
+            {selectedToolType === 'voicemail_detection' && (
+              <>
+                <div>
+                  <Label className="text-xs text-gray-700 dark:text-gray-300">Voicemail Message</Label>
+                  <Textarea
+                    value={formData.vm_message}
+                    onChange={(e) => setFormData(prev => ({ ...prev, vm_message: e.target.value }))}
+                    className="text-xs mt-1 min-h-[60px] resize-none bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100"
+                    placeholder="It looks like I've reached a voicemail. Please call us back when you're available. Thank you, goodbye."
+                  />
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                    Spoken directly (not generated by the LLM). Leave blank to end the call silently, with no message.
+                  </p>
+                </div>
+
+                <div>
+                  <Label className="text-xs text-gray-700 dark:text-gray-300">Reply Wait Timeout (seconds)</Label>
+                  <Input
+                    type="number"
+                    min="0"
+                    step="0.5"
+                    value={formData.vm_wait_timeout}
+                    onChange={(e) => setFormData(prev => ({ ...prev, vm_wait_timeout: Number.parseFloat(e.target.value) || 0 }))}
+                    className="h-7 text-xs mt-1 bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700"
+                    placeholder="7"
+                  />
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                    How long to wait for a reply after speaking before hanging up. Set to 0 to hang up immediately.
                   </p>
                 </div>
               </>

--- a/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/ToolsActionsSettingsProps.tsx
+++ b/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/ToolsActionsSettingsProps.tsx
@@ -11,7 +11,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { Switch } from '@/components/ui/switch'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
-import { PlusIcon, EditIcon, TrashIcon, PhoneOffIcon, ArrowRightIcon, CodeIcon, PhoneForwardedIcon, Loader2, Phone, Hash, MicIcon, Voicemail, Languages, BookOpen } from 'lucide-react'
+import { PlusIcon, EditIcon, TrashIcon, PhoneOffIcon, ArrowRightIcon, CodeIcon, PhoneForwardedIcon, Loader2, Phone, Hash, MicIcon, Voicemail, Languages, BookOpen, Info } from 'lucide-react'
 import LanguageSwitchSettings, { LanguageSwitchConfig } from '../../LanguageSwitchSettings'
 
 export function validateToolName(name: string, allNames: string[]): string | null {
@@ -1590,6 +1590,13 @@ function ToolsActionsSettings({ tools, languageSwitchTools = [], turnDetection, 
             {/* Voicemail Detection specific fields */}
             {selectedToolType === 'voicemail_detection' && (
               <>
+                <div className="flex items-start gap-2 p-2.5 bg-yellow-50 dark:bg-yellow-900/20 rounded-md border border-yellow-200 dark:border-yellow-800">
+                  <Info className="w-3.5 h-3.5 text-yellow-600 mt-0.5 flex-shrink-0" />
+                  <p className="text-xs text-yellow-700 dark:text-yellow-300">
+                    Powered by LiveKit's built-in Answering Machine Detection (AMD). It runs its own dedicated LLM (Azure OpenAI GPT-4.1-mini) and STT (Sarvam saaras:v3, language="unknown" (auto-detect) and mode="transcribe" ) for classification, independent of this agent's configured LLM and STT.
+                  </p>
+                </div>
+
                 <div>
                   <Label className="text-xs text-gray-700 dark:text-gray-300">Voicemail Message</Label>
                   <Textarea

--- a/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/ToolsActionsSettingsProps.tsx
+++ b/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/ToolsActionsSettingsProps.tsx
@@ -37,6 +37,11 @@ const WEBHOOK_FIELD_OPTIONS = [
 ]
 const ALL_WEBHOOK_FIELDS = WEBHOOK_FIELD_OPTIONS.map(f => f.key)
 
+// Voicemail detection fields are irrelevant for every other tool type - shared
+// so the inert reset value isn't repeated verbatim across every handleAddTool
+// branch (was flagged as duplicated code).
+const INERT_VM_FIELDS = { vm_message: '', vm_wait_timeout: 0 }
+
 // ── Filler config ─────────────────────────────────────────────────────────────
 interface FillerConfig {
   enabled: boolean
@@ -178,8 +183,7 @@ function ToolsActionsSettings({ tools, languageSwitchTools = [], turnDetection, 
     hospitals_json: '[]',
     areas_json: '{}',
     // Voicemail detection fields
-    vm_message: '',
-    vm_wait_timeout: 0,
+    ...INERT_VM_FIELDS,
     // Filler words
     filler_config: { ...DEFAULT_FILLER_CONFIG } as FillerConfig,
   })
@@ -260,8 +264,7 @@ function ToolsActionsSettings({ tools, languageSwitchTools = [], turnDetection, 
         max_results: 3,
         hospitals_json: '[]',
         areas_json: '{}',
-        vm_message: '',
-        vm_wait_timeout: 0,
+        ...INERT_VM_FIELDS,
         filler_config: { ...DEFAULT_FILLER_CONFIG },
       })
     } else if (toolType === 'handoff') {
@@ -297,8 +300,7 @@ function ToolsActionsSettings({ tools, languageSwitchTools = [], turnDetection, 
         max_results: 3,
         hospitals_json: '[]',
         areas_json: '{}',
-        vm_message: '',
-        vm_wait_timeout: 0,
+        ...INERT_VM_FIELDS,
         filler_config: { ...DEFAULT_FILLER_CONFIG },
       })
     } else if (toolType === 'transfer_call') {
@@ -334,8 +336,7 @@ function ToolsActionsSettings({ tools, languageSwitchTools = [], turnDetection, 
         max_results: 3,
         hospitals_json: '[]',
         areas_json: '{}',
-        vm_message: '',
-        vm_wait_timeout: 0,
+        ...INERT_VM_FIELDS,
         filler_config: { ...DEFAULT_FILLER_CONFIG },
       })
     } else if (toolType === 'ivr_navigator') {
@@ -371,8 +372,7 @@ function ToolsActionsSettings({ tools, languageSwitchTools = [], turnDetection, 
         max_results: 3,
         hospitals_json: '[]',
         areas_json: '{}',
-        vm_message: '',
-        vm_wait_timeout: 0,
+        ...INERT_VM_FIELDS,
         filler_config: { ...DEFAULT_FILLER_CONFIG },
       })
     } else if (toolType === 'nearby_location_finder') {
@@ -408,8 +408,7 @@ function ToolsActionsSettings({ tools, languageSwitchTools = [], turnDetection, 
         max_results: 3,
         hospitals_json: '[]',
         areas_json: '{}',
-        vm_message: '',
-        vm_wait_timeout: 0,
+        ...INERT_VM_FIELDS,
         filler_config: { ...DEFAULT_FILLER_CONFIG },
       })
     } else if (toolType === 'update_vad_options') {
@@ -445,8 +444,7 @@ function ToolsActionsSettings({ tools, languageSwitchTools = [], turnDetection, 
         max_results: 3,
         hospitals_json: '[]',
         areas_json: '{}',
-        vm_message: '',
-        vm_wait_timeout: 0,
+        ...INERT_VM_FIELDS,
         filler_config: { ...DEFAULT_FILLER_CONFIG },
       })
     } else if (toolType === 'voicemail_detection') {
@@ -519,8 +517,7 @@ function ToolsActionsSettings({ tools, languageSwitchTools = [], turnDetection, 
         max_results: 3,
         hospitals_json: '[]',
         areas_json: '{}',
-        vm_message: '',
-        vm_wait_timeout: 0,
+        ...INERT_VM_FIELDS,
         filler_config: { ...DEFAULT_FILLER_CONFIG },
       })
     }

--- a/src/hooks/useAgentConfig.ts
+++ b/src/hooks/useAgentConfig.ts
@@ -385,7 +385,7 @@ const DEFAULT_TOOL_NAMES: Record<string, string> = {
   voicemail_detection: 'Voicemail Detection',
 }
 
-function getDefaultToolName(type: string): string {
+export function getDefaultToolName(type: string): string {
   return DEFAULT_TOOL_NAMES[type] || 'Custom Tool'
 }
 
@@ -404,7 +404,7 @@ function deserializeLanguageSwitchTool(tool: any) {
   }
 }
 
-function deserializeToolConfig(tool: any) {
+export function deserializeToolConfig(tool: any) {
   return {
     description: tool.description || '',
     endpoint: tool.api_url || '',

--- a/src/hooks/useAgentConfig.ts
+++ b/src/hooks/useAgentConfig.ts
@@ -382,6 +382,7 @@ const DEFAULT_TOOL_NAMES: Record<string, string> = {
   ivr_navigator: 'Send DTMF',
   nearby_location_finder: 'Nearby Hospital Finder',
   update_vad_options: 'Update VAD Options',
+  voicemail_detection: 'Voicemail Detection',
 }
 
 function getDefaultToolName(type: string): string {
@@ -439,6 +440,10 @@ function deserializeToolConfig(tool: any) {
     instruction_template: tool.instruction_template || '',
     default_task: tool.default_task || 'Reach a live support representative',
     task_metadata_keys: tool.task_metadata_keys || ['ivr_task', 'navigator_task', 'task'],
+    // Voicemail detection fields. ?? not || - a blank message / 0 timeout is
+    // an intentional config (instant, silent hangup), not "unset".
+    vm_message: tool.vm_message ?? "It looks like I've reached a voicemail. Please call us back when you're available. Thank you, goodbye.",
+    vm_wait_timeout: tool.vm_wait_timeout ?? 7,
     // Nearby hospital finder fields (kept as JSON strings for editor)
     max_results: tool.max_results ?? 3,
     hospitals_json: JSON.stringify(tool.hospitals ?? [], null, 2),

--- a/src/hooks/useMultiAssistantState.ts
+++ b/src/hooks/useMultiAssistantState.ts
@@ -420,7 +420,7 @@ function serializeIvrNavigatorTool(tool: any, baseToolConfig: any, commonFields:
   }
 }
 
-function serializeVoicemailDetectionTool(tool: any, baseToolConfig: any, commonFields: any): any {
+export function serializeVoicemailDetectionTool(tool: any, baseToolConfig: any, commonFields: any): any {
   return {
     ...baseToolConfig,
     ...commonFields,
@@ -454,7 +454,7 @@ function serializeNearbyLocationFinderTool(tool: any, baseToolConfig: any, commo
   return { ...baseToolConfig, ...commonFields, max_results: maxResults, hospitals, areas }
 }
 
-function serializeAssistantToolFull(tool: any): any {
+export function serializeAssistantToolFull(tool: any): any {
   const baseToolConfig = { type: tool.type }
   if (tool.type === 'end_call') return baseToolConfig
 
@@ -470,7 +470,7 @@ function serializeAssistantToolFull(tool: any): any {
 
 // Used by the multi-assistant save path. Intentionally omits acefone_token / webhook
 // fields for transfer_call — mirrors the pre-existing behavior at this call site.
-function serializeAssistantToolBasic(tool: any): any {
+export function serializeAssistantToolBasic(tool: any): any {
   const baseToolConfig = { type: tool.type }
   if (tool.type === 'end_call') return baseToolConfig
 

--- a/src/hooks/useMultiAssistantState.ts
+++ b/src/hooks/useMultiAssistantState.ts
@@ -420,6 +420,16 @@ function serializeIvrNavigatorTool(tool: any, baseToolConfig: any, commonFields:
   }
 }
 
+function serializeVoicemailDetectionTool(tool: any, baseToolConfig: any, commonFields: any): any {
+  return {
+    ...baseToolConfig,
+    ...commonFields,
+    // ?? not || - a blank message / 0 timeout is an intentional config (instant, silent hangup).
+    vm_message: tool.config?.vm_message ?? "It looks like I've reached a voicemail. Please call us back when you're available. Thank you, goodbye.",
+    vm_wait_timeout: tool.config?.vm_wait_timeout ?? 7,
+  }
+}
+
 function parseNearbyLocationFinderConfig(tool: any): { hospitals: any[]; areas: Record<string, any>; maxResults: number } {
   let hospitals: any[] = []
   let areas: Record<string, any> = {}
@@ -454,6 +464,7 @@ function serializeAssistantToolFull(tool: any): any {
   if (tool.type === 'transfer_call') return serializeTransferCallToolFull(tool, baseToolConfig, commonFields)
   if (tool.type === 'ivr_navigator') return serializeIvrNavigatorTool(tool, baseToolConfig, commonFields)
   if (tool.type === 'nearby_location_finder') return serializeNearbyLocationFinderTool(tool, baseToolConfig, commonFields)
+  if (tool.type === 'voicemail_detection') return serializeVoicemailDetectionTool(tool, baseToolConfig, commonFields)
   return baseToolConfig
 }
 
@@ -469,6 +480,7 @@ function serializeAssistantToolBasic(tool: any): any {
   if (tool.type === 'transfer_call') return serializeTransferCallToolBasic(tool, baseToolConfig, commonFields)
   if (tool.type === 'ivr_navigator') return serializeIvrNavigatorTool(tool, baseToolConfig, commonFields)
   if (tool.type === 'nearby_location_finder') return serializeNearbyLocationFinderTool(tool, baseToolConfig, commonFields)
+  if (tool.type === 'voicemail_detection') return serializeVoicemailDetectionTool(tool, baseToolConfig, commonFields)
   return baseToolConfig
 }
 


### PR DESCRIPTION
## Description

**Summary**

Adds UI support for configuring the new `voicemail_detection` tool (used by the backend's LiveKit AMD prototype), and fixes several pre-existing serialization gaps that silently dropped its config on save.

**Changes**

- Added `vm_message` (voicemail message) and `vm_wait_timeout` (reply-wait timeout) fields to the tool's config dialog (`ToolsActionsSettingsProps.tsx`), with real defaults only in the `voicemail_detection` add-flow — other tool types keep inert blank/0 placeholders.
- Added a yellow callout at the top of the dialog noting this is powered by LiveKit's built-in AMD with its own dedicated LLM (Azure OpenAI GPT-4.1-mini) and STT (Sarvam `saaras:v3`, auto-detect language) — independent of the agent's own configured LLM/STT.
- Fixed the tool's name falling back to "Custom Tool" after an agent update (missing `DEFAULT_TOOL_NAMES` entry in `useAgentConfig.ts`).
- **Fixed silent data loss on save**: `useMultiAssistantState.ts`'s tool serializers (`serializeAssistantToolFull`/`Basic`) had no case for `voicemail_detection`, so every agent update reduced its config to just `{type: 'voicemail_detection'}` — dropping name, description, message, and timeout entirely. Added a dedicated serializer, wired into both save paths.
- `useAgentConfig.ts`'s `deserializeToolConfig` never read `vm_message`/`vm_wait_timeout` back into the edit form; added both using `??` (not `||`) so an intentionally blank message or `0` timeout round-trips correctly instead of reverting to the default.
- `save-and-deploy/route.ts`'s `serializeRouteTool` was missing the same two fields for this tool type; added (kept as a private, in-file function — this route is excluded from unit coverage per this repo's own `vitest.config.ts`, matching how the rest of `src/app/**` is treated).

