### PR TITLE
feat(campaigns): add 'Metadata' retry type to Retry Configuration UI

### DIFF
--- a/src/app/[projectid]/campaigns/[campaignId]/page.tsx
+++ b/src/app/[projectid]/campaigns/[campaignId]/page.tsx
@@ -900,6 +900,8 @@ function ViewCampaign() {
                       displayLabel = `Metric: ${config.metricName} ${config.operator || ''} ${config.threshold ?? ''}`
                     } else if (config.type === 'fieldExtractor' && config.fieldName) {
                       displayLabel = `Field: ${config.fieldName} ${config.operator || ''}`
+                    } else if (config.type === 'metadata' && config.fieldName) {
+                      displayLabel = `Metadata: ${config.fieldName} ${config.operator || ''}`
                     } else {
                       displayLabel = 'Unknown retry type'
                     }

--- a/src/app/[projectid]/campaigns/create/page.tsx
+++ b/src/app/[projectid]/campaigns/create/page.tsx
@@ -421,6 +421,20 @@ function CreateCampaign() {
           }
           if (backoff) fieldConfig.backoffMinutes = backoff
           return fieldConfig
+        } else if (config.type === 'metadata') {
+          const metadataConfig: any = {
+            type: 'metadata',
+            fieldName: config.fieldName,
+            operator: config.operator,
+            delayMinutes: Number(config.delayMinutes),
+            maxRetries: Number(config.maxRetries),
+          }
+          const metadataOperator = config.operator as 'missing' | 'equals' | 'not_equals' | 'contains' | 'not_contains' | undefined
+          if (metadataOperator && metadataOperator !== 'missing' && config.expectedValue) {
+            metadataConfig.expectedValue = config.expectedValue
+          }
+          if (backoff) metadataConfig.backoffMinutes = backoff
+          return metadataConfig
         }
         return config
       })

--- a/src/app/[projectid]/campaigns/create/page.tsx
+++ b/src/app/[projectid]/campaigns/create/page.tsx
@@ -28,7 +28,7 @@ function validateSipCodeRetry(value: any): string | null {
 
 function validateMetricRetry(value: any): string | null {
   // Allow undefined metricName if no options available, but require it if it exists
-  if (value.metricName !== undefined && value.metricName !== null && value.metricName.trim() === '') {
+  if (value.metricName?.trim() === '') {
     return 'Metric name cannot be empty if provided'
   }
   if (!value.operator || !['<', '>', '<=', '>=', '==', '!='].includes(value.operator)) {
@@ -59,7 +59,7 @@ function validateFieldLikeOperator(value: any): string | null {
 
 function validateFieldExtractorRetry(value: any): string | null {
   // Allow undefined fieldName if no options available, but require it if it exists
-  if (value.fieldName !== undefined && value.fieldName !== null && value.fieldName.trim() === '') {
+  if (value.fieldName?.trim() === '') {
     return 'Field name cannot be empty if provided'
   }
   const operatorError = validateFieldLikeOperator(value)
@@ -83,7 +83,7 @@ function validateMetadataRetry(value: any): string | null {
 }
 
 function validateRetryConfigEntry(value: any): string | null {
-  if (!value || !value.type) return null // Let required() handle this
+  if (!value?.type) return null // Let required() handle this
   if (value.type === 'sipCode') return validateSipCodeRetry(value)
   if (value.type === 'metric') return validateMetricRetry(value)
   if (value.type === 'fieldExtractor') return validateFieldExtractorRetry(value)

--- a/src/app/[projectid]/campaigns/create/page.tsx
+++ b/src/app/[projectid]/campaigns/create/page.tsx
@@ -16,6 +16,81 @@ import { ScheduleSelector } from '@/components/campaigns/ScheduleSelector'
 import { RecipientsPreview } from '@/components/campaigns/RecipientsPreview'
 import { RetryConfiguration } from '@/components/campaigns/RetryConfiguration'
 
+// Per-type retryConfig validators — each returns an error message or null.
+// Extracted so the Yup .test() callback below is a flat dispatcher instead
+// of one deeply-branched function.
+function validateSipCodeRetry(value: any): string | null {
+  if (!value.errorCodes || !Array.isArray(value.errorCodes) || value.errorCodes.length === 0) {
+    return 'At least one error code is required for SIP code retries'
+  }
+  return null
+}
+
+function validateMetricRetry(value: any): string | null {
+  // Allow undefined metricName if no options available, but require it if it exists
+  if (value.metricName !== undefined && value.metricName !== null && value.metricName.trim() === '') {
+    return 'Metric name cannot be empty if provided'
+  }
+  if (!value.operator || !['<', '>', '<=', '>=', '==', '!='].includes(value.operator)) {
+    return 'Operator is required and must be one of: <, >, <=, >=, ==, !='
+  }
+  if (value.threshold === undefined || value.threshold === null) {
+    return 'Threshold is required'
+  }
+  // Only require metricName if operator and threshold are set (meaning user is configuring)
+  if (value.operator && value.threshold !== undefined && (!value.metricName || value.metricName.trim() === '')) {
+    return 'Metric name is required'
+  }
+  return null
+}
+
+// Shared operator/expectedValue rules for fieldExtractor and metadata — both
+// use the same operator set and the same "expectedValue required unless
+// missing" rule. Only fieldName presence differs, so each caller checks that.
+function validateFieldLikeOperator(value: any): string | null {
+  if (!value.operator || !['missing', 'equals', 'not_equals', 'contains', 'not_contains'].includes(value.operator)) {
+    return 'Operator is required'
+  }
+  if (value.operator !== 'missing' && (!value.expectedValue || value.expectedValue === '')) {
+    return 'Expected value is required when operator is not "missing"'
+  }
+  return null
+}
+
+function validateFieldExtractorRetry(value: any): string | null {
+  // Allow undefined fieldName if no options available, but require it if it exists
+  if (value.fieldName !== undefined && value.fieldName !== null && value.fieldName.trim() === '') {
+    return 'Field name cannot be empty if provided'
+  }
+  const operatorError = validateFieldLikeOperator(value)
+  if (operatorError) return operatorError
+  // Only require fieldName if operator is set (meaning user is configuring)
+  if (value.operator && (!value.fieldName || value.fieldName.trim() === '')) {
+    return 'Field name is required'
+  }
+  return null
+}
+
+function validateMetadataRetry(value: any): string | null {
+  // fieldName comes from a fixed dropdown (CALL_METADATA_FIELDS), so it's
+  // always present once the row exists — no "empty if provided" check needed.
+  const operatorError = validateFieldLikeOperator(value)
+  if (operatorError) return operatorError
+  if (value.operator && (!value.fieldName || value.fieldName.trim() === '')) {
+    return 'Metadata field is required'
+  }
+  return null
+}
+
+function validateRetryConfigEntry(value: any): string | null {
+  if (!value || !value.type) return null // Let required() handle this
+  if (value.type === 'sipCode') return validateSipCodeRetry(value)
+  if (value.type === 'metric') return validateMetricRetry(value)
+  if (value.type === 'fieldExtractor') return validateFieldExtractorRetry(value)
+  if (value.type === 'metadata') return validateMetadataRetry(value)
+  return null
+}
+
 // Create validation schema with dynamic max concurrency
 const createValidationSchema = (maxConcurrency: number) => Yup.object({
   campaignName: Yup.string()
@@ -84,57 +159,8 @@ const createValidationSchema = (maxConcurrency: number) => Yup.object({
         .nullable()
         .optional(),
     }).test('validate-retry-config', 'Invalid retry configuration', function(value) {
-      if (!value || !value.type) return true // Let required() handle this
-      
-      if (value.type === 'sipCode') {
-        if (!value.errorCodes || !Array.isArray(value.errorCodes) || value.errorCodes.length === 0) {
-          return this.createError({ message: 'At least one error code is required for SIP code retries' })
-        }
-      } else if (value.type === 'metric') {
-        // Allow undefined metricName if no options available, but require it if it exists
-        if (value.metricName !== undefined && value.metricName !== null && value.metricName.trim() === '') {
-          return this.createError({ message: 'Metric name cannot be empty if provided' })
-        }
-        if (!value.operator || !['<', '>', '<=', '>=', '==', '!='].includes(value.operator)) {
-          return this.createError({ message: 'Operator is required and must be one of: <, >, <=, >=, ==, !=' })
-        }
-        if (value.threshold === undefined || value.threshold === null) {
-          return this.createError({ message: 'Threshold is required' })
-        }
-        // Only require metricName if operator and threshold are set (meaning user is configuring)
-        if (value.operator && value.threshold !== undefined && (!value.metricName || value.metricName.trim() === '')) {
-          return this.createError({ message: 'Metric name is required' })
-        }
-      } else if (value.type === 'fieldExtractor') {
-        // Allow undefined fieldName if no options available, but require it if it exists
-        if (value.fieldName !== undefined && value.fieldName !== null && value.fieldName.trim() === '') {
-          return this.createError({ message: 'Field name cannot be empty if provided' })
-        }
-        if (!value.operator || !['missing', 'equals', 'not_equals', 'contains', 'not_contains'].includes(value.operator)) {
-          return this.createError({ message: 'Operator is required' })
-        }
-        if (value.operator !== 'missing' && (!value.expectedValue || value.expectedValue === '')) {
-          return this.createError({ message: 'Expected value is required when operator is not "missing"' })
-        }
-        // Only require fieldName if operator is set (meaning user is configuring)
-        if (value.operator && (!value.fieldName || value.fieldName.trim() === '')) {
-          return this.createError({ message: 'Field name is required' })
-        }
-      } else if (value.type === 'metadata') {
-        // fieldName comes from a fixed dropdown (CALL_METADATA_FIELDS), so
-        // it's always present once the row exists — same operator/expectedValue
-        // rules as fieldExtractor.
-        if (!value.operator || !['missing', 'equals', 'not_equals', 'contains', 'not_contains'].includes(value.operator)) {
-          return this.createError({ message: 'Operator is required' })
-        }
-        if (value.operator !== 'missing' && (!value.expectedValue || value.expectedValue === '')) {
-          return this.createError({ message: 'Expected value is required when operator is not "missing"' })
-        }
-        if (value.operator && (!value.fieldName || value.fieldName.trim() === '')) {
-          return this.createError({ message: 'Metadata field is required' })
-        }
-      }
-      return true
+      const errorMessage = validateRetryConfigEntry(value)
+      return errorMessage ? this.createError({ message: errorMessage }) : true
     })
   ).test(
     'no-duplicate-sip-codes',

--- a/src/app/[projectid]/campaigns/create/page.tsx
+++ b/src/app/[projectid]/campaigns/create/page.tsx
@@ -194,6 +194,69 @@ async function resolveCampaignAgentName(agentId: string, agentRuntime: string): 
   return agentId
 }
 
+// Sanitize an optional backoffMinutes array: ints in [5, 1440], up to 10.
+function sanitizeBackoffMinutes(raw: unknown): number[] | undefined {
+  if (!Array.isArray(raw) || raw.length === 0) return undefined
+  const cleaned = raw
+    .map(v => Number(v))
+    .filter(n => Number.isFinite(n) && n >= 5 && n <= 1440)
+    .slice(0, 10)
+  return cleaned.length > 0 ? cleaned : undefined
+}
+
+// Format a single retryConfig entry according to backend requirements. Each
+// branch explicitly lists its fields, so backoffMinutes MUST be carried
+// through here or it gets silently dropped. fieldExtractor and metadata
+// share identical shape/logic — only the `type` value differs — so they're
+// handled by one branch.
+function formatRetryConfigEntry(config: RetryConfig): any {
+  const backoff = sanitizeBackoffMinutes((config as any).backoffMinutes)
+
+  if (config.type === 'sipCode' || !config.type) {
+    const out: any = {
+      type: 'sipCode',
+      errorCodes: Array.isArray(config.errorCodes)
+        ? config.errorCodes.map(code => String(code).trim()).filter(code => code.length > 0)
+        : (config.errorCodes ? [String(config.errorCodes).trim()] : ['480']),
+      delayMinutes: Number(config.delayMinutes),
+      maxRetries: Number(config.maxRetries),
+    }
+    if (backoff) out.backoffMinutes = backoff
+    return out
+  }
+
+  if (config.type === 'metric') {
+    const metricConfig: any = {
+      type: 'metric',
+      metricName: config.metricName,
+      operator: config.operator,
+      threshold: Number(config.threshold),
+      delayMinutes: Number(config.delayMinutes),
+      maxRetries: Number(config.maxRetries),
+    }
+    if (backoff) metricConfig.backoffMinutes = backoff
+    return metricConfig
+  }
+
+  if (config.type === 'fieldExtractor' || config.type === 'metadata') {
+    const fieldConfig: any = {
+      type: config.type,
+      fieldName: config.fieldName,
+      operator: config.operator,
+      delayMinutes: Number(config.delayMinutes),
+      maxRetries: Number(config.maxRetries),
+    }
+    const operator = config.operator as 'missing' | 'equals' | 'not_equals' | 'contains' | 'not_contains' | undefined
+    if (operator && operator !== 'missing' && config.expectedValue) {
+      fieldConfig.expectedValue = config.expectedValue
+    }
+    if (backoff) fieldConfig.backoffMinutes = backoff
+    return fieldConfig
+  }
+
+  return config
+}
+
 function CreateCampaign() {
   const router = useRouter()
   const params = useParams()
@@ -370,74 +433,9 @@ function CreateCampaign() {
         ? new Date(values.scheduleDate).toISOString()
         : new Date().toISOString()
 
-      // Sanitize an optional backoffMinutes array: ints in [5, 1440], up to 10.
-      const sanitizeBackoff = (raw: unknown): number[] | undefined => {
-        if (!Array.isArray(raw) || raw.length === 0) return undefined
-        const cleaned = raw
-          .map(v => Number(v))
-          .filter(n => Number.isFinite(n) && n >= 5 && n <= 1440)
-          .slice(0, 10)
-        return cleaned.length > 0 ? cleaned : undefined
-      }
-
-      // Format retryConfig according to backend requirements. Each branch
-      // explicitly lists its fields, so backoffMinutes MUST be carried
-      // through here or it gets silently dropped.
-      const formattedRetryConfig = values.retryConfig.map(config => {
-        const backoff = sanitizeBackoff((config as any).backoffMinutes)
-        if (config.type === 'sipCode' || !config.type) {
-          const out: any = {
-            type: 'sipCode',
-            errorCodes: Array.isArray(config.errorCodes)
-              ? config.errorCodes.map(code => String(code).trim()).filter(code => code.length > 0)
-              : (config.errorCodes ? [String(config.errorCodes).trim()] : ['480']),
-            delayMinutes: Number(config.delayMinutes),
-            maxRetries: Number(config.maxRetries),
-          }
-          if (backoff) out.backoffMinutes = backoff
-          return out
-        } else if (config.type === 'metric') {
-          const metricConfig: any = {
-            type: 'metric',
-            metricName: config.metricName,
-            operator: config.operator,
-            threshold: Number(config.threshold),
-            delayMinutes: Number(config.delayMinutes),
-            maxRetries: Number(config.maxRetries),
-          }
-          if (backoff) metricConfig.backoffMinutes = backoff
-          return metricConfig
-        } else if (config.type === 'fieldExtractor') {
-          const fieldConfig: any = {
-            type: 'fieldExtractor',
-            fieldName: config.fieldName,
-            operator: config.operator,
-            delayMinutes: Number(config.delayMinutes),
-            maxRetries: Number(config.maxRetries),
-          }
-          const fieldOperator = config.operator as 'missing' | 'equals' | 'not_equals' | 'contains' | 'not_contains' | undefined
-          if (fieldOperator && fieldOperator !== 'missing' && config.expectedValue) {
-            fieldConfig.expectedValue = config.expectedValue
-          }
-          if (backoff) fieldConfig.backoffMinutes = backoff
-          return fieldConfig
-        } else if (config.type === 'metadata') {
-          const metadataConfig: any = {
-            type: 'metadata',
-            fieldName: config.fieldName,
-            operator: config.operator,
-            delayMinutes: Number(config.delayMinutes),
-            maxRetries: Number(config.maxRetries),
-          }
-          const metadataOperator = config.operator as 'missing' | 'equals' | 'not_equals' | 'contains' | 'not_contains' | undefined
-          if (metadataOperator && metadataOperator !== 'missing' && config.expectedValue) {
-            metadataConfig.expectedValue = config.expectedValue
-          }
-          if (backoff) metadataConfig.backoffMinutes = backoff
-          return metadataConfig
-        }
-        return config
-      })
+      // Format retryConfig according to backend requirements (see
+      // formatRetryConfigEntry for the per-type field shapes).
+      const formattedRetryConfig = values.retryConfig.map(formatRetryConfigEntry)
 
       const scheduleResponse = await fetch('/api/campaigns/schedule', {
         method: 'POST',

--- a/src/app/[projectid]/campaigns/create/page.tsx
+++ b/src/app/[projectid]/campaigns/create/page.tsx
@@ -198,62 +198,73 @@ async function resolveCampaignAgentName(agentId: string, agentRuntime: string): 
 function sanitizeBackoffMinutes(raw: unknown): number[] | undefined {
   if (!Array.isArray(raw) || raw.length === 0) return undefined
   const cleaned = raw
-    .map(v => Number(v))
+    .map(Number)
     .filter(n => Number.isFinite(n) && n >= 5 && n <= 1440)
     .slice(0, 10)
   return cleaned.length > 0 ? cleaned : undefined
 }
 
-// Format a single retryConfig entry according to backend requirements. Each
-// branch explicitly lists its fields, so backoffMinutes MUST be carried
-// through here or it gets silently dropped. fieldExtractor and metadata
-// share identical shape/logic — only the `type` value differs — so they're
-// handled by one branch.
+// sipCode retries accept errorCodes as an array, a single value, or nothing
+// (defaults to ['480']) — one statement per case rather than a nested
+// ternary so each outcome reads plainly.
+function normalizeErrorCodes(errorCodes: unknown): string[] {
+  if (Array.isArray(errorCodes)) {
+    return errorCodes.map(code => String(code).trim()).filter(code => code.length > 0)
+  }
+  if (errorCodes) {
+    return [String(errorCodes).trim()]
+  }
+  return ['480']
+}
+
+function buildSipCodeConfig(config: RetryConfig, backoff: number[] | undefined): any {
+  const out: any = {
+    type: 'sipCode',
+    errorCodes: normalizeErrorCodes(config.errorCodes),
+    delayMinutes: Number(config.delayMinutes),
+    maxRetries: Number(config.maxRetries),
+  }
+  if (backoff) out.backoffMinutes = backoff
+  return out
+}
+
+function buildMetricConfig(config: RetryConfig, backoff: number[] | undefined): any {
+  const metricConfig: any = {
+    type: 'metric',
+    metricName: config.metricName,
+    operator: config.operator,
+    threshold: Number(config.threshold),
+    delayMinutes: Number(config.delayMinutes),
+    maxRetries: Number(config.maxRetries),
+  }
+  if (backoff) metricConfig.backoffMinutes = backoff
+  return metricConfig
+}
+
+// Shared shape for fieldExtractor and metadata — only `type` differs.
+function buildFieldOrMetadataConfig(config: RetryConfig, backoff: number[] | undefined): any {
+  const fieldConfig: any = {
+    type: config.type,
+    fieldName: config.fieldName,
+    operator: config.operator,
+    delayMinutes: Number(config.delayMinutes),
+    maxRetries: Number(config.maxRetries),
+  }
+  const operator = config.operator as 'missing' | 'equals' | 'not_equals' | 'contains' | 'not_contains' | undefined
+  if (operator && operator !== 'missing' && config.expectedValue) {
+    fieldConfig.expectedValue = config.expectedValue
+  }
+  if (backoff) fieldConfig.backoffMinutes = backoff
+  return fieldConfig
+}
+
+// Format a single retryConfig entry according to backend requirements — see
+// the per-type builders above for field shapes.
 function formatRetryConfigEntry(config: RetryConfig): any {
   const backoff = sanitizeBackoffMinutes((config as any).backoffMinutes)
-
-  if (config.type === 'sipCode' || !config.type) {
-    const out: any = {
-      type: 'sipCode',
-      errorCodes: Array.isArray(config.errorCodes)
-        ? config.errorCodes.map(code => String(code).trim()).filter(code => code.length > 0)
-        : (config.errorCodes ? [String(config.errorCodes).trim()] : ['480']),
-      delayMinutes: Number(config.delayMinutes),
-      maxRetries: Number(config.maxRetries),
-    }
-    if (backoff) out.backoffMinutes = backoff
-    return out
-  }
-
-  if (config.type === 'metric') {
-    const metricConfig: any = {
-      type: 'metric',
-      metricName: config.metricName,
-      operator: config.operator,
-      threshold: Number(config.threshold),
-      delayMinutes: Number(config.delayMinutes),
-      maxRetries: Number(config.maxRetries),
-    }
-    if (backoff) metricConfig.backoffMinutes = backoff
-    return metricConfig
-  }
-
-  if (config.type === 'fieldExtractor' || config.type === 'metadata') {
-    const fieldConfig: any = {
-      type: config.type,
-      fieldName: config.fieldName,
-      operator: config.operator,
-      delayMinutes: Number(config.delayMinutes),
-      maxRetries: Number(config.maxRetries),
-    }
-    const operator = config.operator as 'missing' | 'equals' | 'not_equals' | 'contains' | 'not_contains' | undefined
-    if (operator && operator !== 'missing' && config.expectedValue) {
-      fieldConfig.expectedValue = config.expectedValue
-    }
-    if (backoff) fieldConfig.backoffMinutes = backoff
-    return fieldConfig
-  }
-
+  if (config.type === 'sipCode' || !config.type) return buildSipCodeConfig(config, backoff)
+  if (config.type === 'metric') return buildMetricConfig(config, backoff)
+  if (config.type === 'fieldExtractor' || config.type === 'metadata') return buildFieldOrMetadataConfig(config, backoff)
   return config
 }
 

--- a/src/app/[projectid]/campaigns/create/page.tsx
+++ b/src/app/[projectid]/campaigns/create/page.tsx
@@ -204,14 +204,16 @@ function sanitizeBackoffMinutes(raw: unknown): number[] | undefined {
   return cleaned.length > 0 ? cleaned : undefined
 }
 
-// sipCode retries accept errorCodes as an array, a single value, or nothing
-// (defaults to ['480']) — one statement per case rather than a nested
-// ternary so each outcome reads plainly.
+// sipCode retries accept errorCodes as an array, a single string/number, or
+// nothing (defaults to ['480']) — one statement per case rather than a
+// nested ternary so each outcome reads plainly. Anything else (e.g. an
+// object) falls through to the default rather than being stringified into
+// "[object Object]".
 function normalizeErrorCodes(errorCodes: unknown): string[] {
   if (Array.isArray(errorCodes)) {
     return errorCodes.map(code => String(code).trim()).filter(code => code.length > 0)
   }
-  if (errorCodes) {
+  if (typeof errorCodes === 'string' || typeof errorCodes === 'number') {
     return [String(errorCodes).trim()]
   }
   return ['480']

--- a/src/app/[projectid]/campaigns/create/page.tsx
+++ b/src/app/[projectid]/campaigns/create/page.tsx
@@ -48,7 +48,7 @@ const createValidationSchema = (maxConcurrency: number) => Yup.object({
     
   retryConfig: Yup.array().of(
     Yup.object().shape({
-      type: Yup.string().oneOf(['sipCode', 'metric', 'fieldExtractor']).required('Retry type is required'),
+      type: Yup.string().oneOf(['sipCode', 'metric', 'fieldExtractor', 'metadata']).required('Retry type is required'),
       // SIP Code fields (optional, but required if type is sipCode)
       errorCodes: Yup.array().of(
         Yup.string().oneOf(VALID_SIP_ERROR_CODE_VALUES, 'Invalid SIP error code')
@@ -119,6 +119,19 @@ const createValidationSchema = (maxConcurrency: number) => Yup.object({
         // Only require fieldName if operator is set (meaning user is configuring)
         if (value.operator && (!value.fieldName || value.fieldName.trim() === '')) {
           return this.createError({ message: 'Field name is required' })
+        }
+      } else if (value.type === 'metadata') {
+        // fieldName comes from a fixed dropdown (CALL_METADATA_FIELDS), so
+        // it's always present once the row exists — same operator/expectedValue
+        // rules as fieldExtractor.
+        if (!value.operator || !['missing', 'equals', 'not_equals', 'contains', 'not_contains'].includes(value.operator)) {
+          return this.createError({ message: 'Operator is required' })
+        }
+        if (value.operator !== 'missing' && (!value.expectedValue || value.expectedValue === '')) {
+          return this.createError({ message: 'Expected value is required when operator is not "missing"' })
+        }
+        if (value.operator && (!value.fieldName || value.fieldName.trim() === '')) {
+          return this.createError({ message: 'Metadata field is required' })
         }
       }
       return true

--- a/src/app/api/campaigns/schedule/route.ts
+++ b/src/app/api/campaigns/schedule/route.ts
@@ -1,6 +1,6 @@
 // app/api/campaigns/schedule/route.ts
 import { NextRequest, NextResponse } from 'next/server'
-import { VALID_SIP_ERROR_CODE_VALUES, CALL_METADATA_FIELDS } from '@/utils/campaigns/constants'
+import { VALID_SIP_ERROR_CODE_VALUES, VALID_CALL_METADATA_FIELD_KEYS } from '@/utils/campaigns/constants'
 
 const badRequest = (error: string) => NextResponse.json({ error }, { status: 400 })
 
@@ -183,9 +183,10 @@ export async function POST(request: NextRequest) {
           // Metadata retry: same shape as fieldExtractor, but fieldName must
           // be one of the fixed call-level metadata keys the voice agent
           // actually produces (e.g. amd-verdict) rather than an arbitrary string.
-          const validFieldNames = CALL_METADATA_FIELDS.map(f => f.key)
-          if (!config.fieldName || !validFieldNames.includes(config.fieldName)) {
-            return badRequest(`Invalid retry configuration: fieldName must be one of: ${validFieldNames.join(', ')}`)
+          // Only enabled keys are accepted — hangup_cause/call_ended_reason
+          // are disabled until something actually writes them.
+          if (!config.fieldName || !VALID_CALL_METADATA_FIELD_KEYS.includes(config.fieldName)) {
+            return badRequest(`Invalid retry configuration: fieldName must be one of: ${VALID_CALL_METADATA_FIELD_KEYS.join(', ')}`)
           }
 
           const commonError = validateFieldLikeCommon(config, 'metadata')

--- a/src/app/api/campaigns/schedule/route.ts
+++ b/src/app/api/campaigns/schedule/route.ts
@@ -2,6 +2,31 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { VALID_SIP_ERROR_CODE_VALUES, CALL_METADATA_FIELDS } from '@/utils/campaigns/constants'
 
+const badRequest = (error: string) => NextResponse.json({ error }, { status: 400 })
+
+const FIELD_LIKE_OPERATORS = ['missing', 'equals', 'not_equals', 'contains', 'not_contains']
+
+// Shared validation for fieldExtractor and metadata retry types: neither
+// allows errorCodes, both use the same operator set, and both require
+// expectedValue whenever the operator isn't 'missing'. Only fieldName
+// validation differs between the two (arbitrary string vs. a fixed list),
+// so that stays in each caller.
+function validateFieldLikeCommon(config: any, retryTypeLabel: string): ReturnType<typeof NextResponse.json> | null {
+  if (config.errorCodes !== undefined) {
+    return badRequest(`Invalid retry configuration: errorCodes should not be present for ${retryTypeLabel} retries`)
+  }
+
+  if (!config.operator || !FIELD_LIKE_OPERATORS.includes(config.operator)) {
+    return badRequest(`Invalid retry configuration: operator must be one of: ${FIELD_LIKE_OPERATORS.join(', ')}`)
+  }
+
+  if (config.operator !== 'missing' && (!config.expectedValue || config.expectedValue === '')) {
+    return badRequest('Invalid retry configuration: expectedValue is required when operator is not "missing"')
+  }
+
+  return null
+}
+
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
@@ -147,76 +172,26 @@ export async function POST(request: NextRequest) {
             )
           }
         } else if (retryType === 'fieldExtractor') {
-          // Field Extractor retry: errorCodes should NOT be present
-          if (config.errorCodes !== undefined) {
-            return NextResponse.json(
-              { error: 'Invalid retry configuration: errorCodes should not be present for field extractor retries' },
-              { status: 400 }
-            )
-          }
-
           // Validate field extractor-specific fields
           if (!config.fieldName || typeof config.fieldName !== 'string' || config.fieldName.trim() === '') {
-            return NextResponse.json(
-              { error: 'Invalid retry configuration: fieldName is required for field extractor retries' },
-              { status: 400 }
-            )
+            return badRequest('Invalid retry configuration: fieldName is required for field extractor retries')
           }
 
-          const validOperators = ['missing', 'equals', 'not_equals', 'contains', 'not_contains']
-          if (!config.operator || !validOperators.includes(config.operator)) {
-            return NextResponse.json(
-              { error: `Invalid retry configuration: operator must be one of: ${validOperators.join(', ')}` },
-              { status: 400 }
-            )
-          }
-
-          // expectedValue is required if operator is not 'missing'
-          if (config.operator !== 'missing' && (!config.expectedValue || config.expectedValue === '')) {
-            return NextResponse.json(
-              { error: 'Invalid retry configuration: expectedValue is required when operator is not "missing"' },
-              { status: 400 }
-            )
-          }
+          const commonError = validateFieldLikeCommon(config, 'field extractor')
+          if (commonError) return commonError
         } else if (retryType === 'metadata') {
           // Metadata retry: same shape as fieldExtractor, but fieldName must
           // be one of the fixed call-level metadata keys the voice agent
           // actually produces (e.g. amd-verdict) rather than an arbitrary string.
-          if (config.errorCodes !== undefined) {
-            return NextResponse.json(
-              { error: 'Invalid retry configuration: errorCodes should not be present for metadata retries' },
-              { status: 400 }
-            )
-          }
-
           const validFieldNames = CALL_METADATA_FIELDS.map(f => f.key)
           if (!config.fieldName || !validFieldNames.includes(config.fieldName)) {
-            return NextResponse.json(
-              { error: `Invalid retry configuration: fieldName must be one of: ${validFieldNames.join(', ')}` },
-              { status: 400 }
-            )
+            return badRequest(`Invalid retry configuration: fieldName must be one of: ${validFieldNames.join(', ')}`)
           }
 
-          const validOperators = ['missing', 'equals', 'not_equals', 'contains', 'not_contains']
-          if (!config.operator || !validOperators.includes(config.operator)) {
-            return NextResponse.json(
-              { error: `Invalid retry configuration: operator must be one of: ${validOperators.join(', ')}` },
-              { status: 400 }
-            )
-          }
-
-          // expectedValue is required if operator is not 'missing'
-          if (config.operator !== 'missing' && (!config.expectedValue || config.expectedValue === '')) {
-            return NextResponse.json(
-              { error: 'Invalid retry configuration: expectedValue is required when operator is not "missing"' },
-              { status: 400 }
-            )
-          }
+          const commonError = validateFieldLikeCommon(config, 'metadata')
+          if (commonError) return commonError
         } else {
-          return NextResponse.json(
-            { error: `Invalid retry configuration: unknown retry type "${retryType}". Valid types are: sipCode, metric, fieldExtractor, metadata` },
-            { status: 400 }
-          )
+          return badRequest(`Invalid retry configuration: unknown retry type "${retryType}". Valid types are: sipCode, metric, fieldExtractor, metadata`)
         }
       }
     }

--- a/src/app/api/campaigns/schedule/route.ts
+++ b/src/app/api/campaigns/schedule/route.ts
@@ -1,6 +1,6 @@
 // app/api/campaigns/schedule/route.ts
 import { NextRequest, NextResponse } from 'next/server'
-import { VALID_SIP_ERROR_CODE_VALUES } from '@/utils/campaigns/constants'
+import { VALID_SIP_ERROR_CODE_VALUES, CALL_METADATA_FIELDS } from '@/utils/campaigns/constants'
 
 export async function POST(request: NextRequest) {
   try {
@@ -178,9 +178,43 @@ export async function POST(request: NextRequest) {
               { status: 400 }
             )
           }
+        } else if (retryType === 'metadata') {
+          // Metadata retry: same shape as fieldExtractor, but fieldName must
+          // be one of the fixed call-level metadata keys the voice agent
+          // actually produces (e.g. amd-verdict) rather than an arbitrary string.
+          if (config.errorCodes !== undefined) {
+            return NextResponse.json(
+              { error: 'Invalid retry configuration: errorCodes should not be present for metadata retries' },
+              { status: 400 }
+            )
+          }
+
+          const validFieldNames = CALL_METADATA_FIELDS.map(f => f.key)
+          if (!config.fieldName || !validFieldNames.includes(config.fieldName)) {
+            return NextResponse.json(
+              { error: `Invalid retry configuration: fieldName must be one of: ${validFieldNames.join(', ')}` },
+              { status: 400 }
+            )
+          }
+
+          const validOperators = ['missing', 'equals', 'not_equals', 'contains', 'not_contains']
+          if (!config.operator || !validOperators.includes(config.operator)) {
+            return NextResponse.json(
+              { error: `Invalid retry configuration: operator must be one of: ${validOperators.join(', ')}` },
+              { status: 400 }
+            )
+          }
+
+          // expectedValue is required if operator is not 'missing'
+          if (config.operator !== 'missing' && (!config.expectedValue || config.expectedValue === '')) {
+            return NextResponse.json(
+              { error: 'Invalid retry configuration: expectedValue is required when operator is not "missing"' },
+              { status: 400 }
+            )
+          }
         } else {
           return NextResponse.json(
-            { error: `Invalid retry configuration: unknown retry type "${retryType}". Valid types are: sipCode, metric, fieldExtractor` },
+            { error: `Invalid retry configuration: unknown retry type "${retryType}". Valid types are: sipCode, metric, fieldExtractor, metadata` },
             { status: 400 }
           )
         }

--- a/src/components/campaigns/RetryConfiguration.tsx
+++ b/src/components/campaigns/RetryConfiguration.tsx
@@ -265,6 +265,60 @@ function SipCodeGroup({
   )
 }
 
+// Shared "Operator" select + "Expected Value" input — identical shape for
+// Field Extractor and Metadata retry types, only the expected-value
+// placeholder differs.
+function OperatorAndExpectedValueFields({
+  operator,
+  expectedValue,
+  onOperatorChange,
+  onExpectedValueChange,
+  expectedValuePlaceholder,
+}: Readonly<{
+  operator?: string
+  expectedValue?: any
+  onOperatorChange: (value: 'missing' | 'equals' | 'not_equals' | 'contains' | 'not_contains') => void
+  onExpectedValueChange: (value: string) => void
+  expectedValuePlaceholder: string
+}>) {
+  return (
+    <>
+      <div>
+        <Label className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-1.5 block">
+          Operator
+        </Label>
+        <Select value={operator || 'missing'} onValueChange={onOperatorChange}>
+          <SelectTrigger className="h-9 text-sm">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="missing">Missing</SelectItem>
+            <SelectItem value="equals">Equals</SelectItem>
+            <SelectItem value="not_equals">Not Equals</SelectItem>
+            <SelectItem value="contains">Contains</SelectItem>
+            <SelectItem value="not_contains">Not Contains</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {operator && operator !== 'missing' && (
+        <div>
+          <Label className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-1.5 block">
+            Expected Value
+          </Label>
+          <Input
+            type="text"
+            value={expectedValue || ''}
+            onChange={(e) => onExpectedValueChange(e.target.value)}
+            className="h-9 text-sm"
+            placeholder={expectedValuePlaceholder}
+          />
+        </div>
+      )}
+    </>
+  )
+}
+
 interface RetryConfigurationProps {
   onFieldChange: (field: string, value: any) => void
   values: {
@@ -724,50 +778,18 @@ export function RetryConfiguration({ onFieldChange, values }: RetryConfiguration
                     </div>
 
                     {config.fieldName && (
-                      <>
-                        <div>
-                          <Label className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-1.5 block">
-                            Operator
-                          </Label>
-                          <Select
-                            value={config.operator || 'missing'}
-                            onValueChange={(value: 'missing' | 'equals' | 'not_equals' | 'contains' | 'not_contains') => {
-                              handleRetryChange(index, 'operator', value)
-                              if (value === 'missing') {
-                                handleRetryChange(index, 'expectedValue', undefined)
-                              }
-                            }}
-                          >
-                            <SelectTrigger className="h-9 text-sm">
-                              <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent>
-                              <SelectItem value="missing">Missing</SelectItem>
-                              <SelectItem value="equals">Equals</SelectItem>
-                              <SelectItem value="not_equals">Not Equals</SelectItem>
-                              <SelectItem value="contains">Contains</SelectItem>
-                              <SelectItem value="not_contains">Not Contains</SelectItem>
-                            </SelectContent>
-                          </Select>
-                        </div>
-
-                        {config.operator && (config.operator as string) !== 'missing' && (
-                          <div>
-                            <Label className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-1.5 block">
-                              Expected Value
-                            </Label>
-                            <Input
-                              type="text"
-                              value={config.expectedValue || ''}
-                              onChange={(e) => {
-                                handleRetryChange(index, 'expectedValue', e.target.value)
-                              }}
-                              className="h-9 text-sm"
-                              placeholder="Enter expected value"
-                            />
-                          </div>
-                        )}
-                      </>
+                      <OperatorAndExpectedValueFields
+                        operator={config.operator}
+                        expectedValue={config.expectedValue}
+                        onOperatorChange={(value) => {
+                          handleRetryChange(index, 'operator', value)
+                          if (value === 'missing') {
+                            handleRetryChange(index, 'expectedValue', undefined)
+                          }
+                        }}
+                        onExpectedValueChange={(value) => handleRetryChange(index, 'expectedValue', value)}
+                        expectedValuePlaceholder="Enter expected value"
+                      />
                     )}
                   </>
                 )}
@@ -801,48 +823,18 @@ export function RetryConfiguration({ onFieldChange, values }: RetryConfiguration
                       </p>
                     </div>
 
-                    <div>
-                      <Label className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-1.5 block">
-                        Operator
-                      </Label>
-                      <Select
-                        value={config.operator || 'missing'}
-                        onValueChange={(value: 'missing' | 'equals' | 'not_equals' | 'contains' | 'not_contains') => {
-                          handleRetryChange(index, 'operator', value)
-                          if (value === 'missing') {
-                            handleRetryChange(index, 'expectedValue', undefined)
-                          }
-                        }}
-                      >
-                        <SelectTrigger className="h-9 text-sm">
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="missing">Missing</SelectItem>
-                          <SelectItem value="equals">Equals</SelectItem>
-                          <SelectItem value="not_equals">Not Equals</SelectItem>
-                          <SelectItem value="contains">Contains</SelectItem>
-                          <SelectItem value="not_contains">Not Contains</SelectItem>
-                        </SelectContent>
-                      </Select>
-                    </div>
-
-                    {config.operator && (config.operator as string) !== 'missing' && (
-                      <div>
-                        <Label className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-1.5 block">
-                          Expected Value
-                        </Label>
-                        <Input
-                          type="text"
-                          value={config.expectedValue || ''}
-                          onChange={(e) => {
-                            handleRetryChange(index, 'expectedValue', e.target.value)
-                          }}
-                          className="h-9 text-sm"
-                          placeholder="e.g. machine_vm"
-                        />
-                      </div>
-                    )}
+                    <OperatorAndExpectedValueFields
+                      operator={config.operator}
+                      expectedValue={config.expectedValue}
+                      onOperatorChange={(value) => {
+                        handleRetryChange(index, 'operator', value)
+                        if (value === 'missing') {
+                          handleRetryChange(index, 'expectedValue', undefined)
+                        }
+                      }}
+                      onExpectedValueChange={(value) => handleRetryChange(index, 'expectedValue', value)}
+                      expectedValuePlaceholder="e.g. machine_vm"
+                    />
                   </>
                 )}
 

--- a/src/components/campaigns/RetryConfiguration.tsx
+++ b/src/components/campaigns/RetryConfiguration.tsx
@@ -618,9 +618,11 @@ export function RetryConfiguration({ onFieldChange, values }: RetryConfiguration
                     } else if (value === 'metadata') {
                       // Call-level metadata (e.g. AMD verdict) — fixed field
                       // list, not agent-specific, so always has a default.
+                      // Default to the first ENABLED field — hangup_cause/
+                      // call_ended_reason are listed but disabled for now.
                       const newConfig: any = {
                         type: 'metadata',
-                        fieldName: CALL_METADATA_FIELDS[0].key,
+                        fieldName: (CALL_METADATA_FIELDS.find(f => f.enabled) || CALL_METADATA_FIELDS[0]).key,
                         operator: 'missing',
                         delayMinutes: config.delayMinutes || 5,
                         maxRetries: config.maxRetries || 2,
@@ -802,7 +804,7 @@ export function RetryConfiguration({ onFieldChange, values }: RetryConfiguration
                         Metadata Field
                       </Label>
                       <Select
-                        value={config.fieldName || CALL_METADATA_FIELDS[0].key}
+                        value={config.fieldName || (CALL_METADATA_FIELDS.find(f => f.enabled) || CALL_METADATA_FIELDS[0]).key}
                         onValueChange={(value) => {
                           handleRetryChange(index, 'fieldName', value)
                         }}
@@ -812,8 +814,9 @@ export function RetryConfiguration({ onFieldChange, values }: RetryConfiguration
                         </SelectTrigger>
                         <SelectContent>
                           {CALL_METADATA_FIELDS.map((field) => (
-                            <SelectItem key={field.key} value={field.key}>
+                            <SelectItem key={field.key} value={field.key} disabled={!field.enabled}>
                               {field.label}
+                              {!field.enabled && <span className="ml-1 text-[10px] italic">(coming soon)</span>}
                             </SelectItem>
                           ))}
                         </SelectContent>

--- a/src/components/campaigns/RetryConfiguration.tsx
+++ b/src/components/campaigns/RetryConfiguration.tsx
@@ -9,7 +9,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { RefreshCw, Info, Plus, X, Loader2 } from 'lucide-react'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
-import { RetryConfig, VALID_SIP_ERROR_CODES, SIP_CODE_GROUPS, SipCode, SipCodeGroup as SipCodeGroupType } from '@/utils/campaigns/constants'
+import { RetryConfig, VALID_SIP_ERROR_CODES, SIP_CODE_GROUPS, SipCode, SipCodeGroup as SipCodeGroupType, CALL_METADATA_FIELDS } from '@/utils/campaigns/constants'
 
 // Chip-style input: type a value, press Enter/Add to append it (after
 // validation), click the X on a chip to remove it. Used for both SIP error
@@ -521,7 +521,7 @@ export function RetryConfiguration({ onFieldChange, values }: RetryConfiguration
                 </Label>
                 <Select
                   value={retryType}
-                  onValueChange={(value: 'sipCode' | 'metric' | 'fieldExtractor') => {
+                  onValueChange={(value: 'sipCode' | 'metric' | 'fieldExtractor' | 'metadata') => {
                     // Create a new config based on the selected type, preserving common fields
                     const updatedConfig = [...values.retryConfig]
                     
@@ -561,8 +561,19 @@ export function RetryConfiguration({ onFieldChange, values }: RetryConfiguration
                         newConfig.fieldName = availableFields[0]
                       }
                       updatedConfig[index] = newConfig as unknown as RetryConfig
+                    } else if (value === 'metadata') {
+                      // Call-level metadata (e.g. AMD verdict) — fixed field
+                      // list, not agent-specific, so always has a default.
+                      const newConfig: any = {
+                        type: 'metadata',
+                        fieldName: CALL_METADATA_FIELDS[0].key,
+                        operator: 'missing',
+                        delayMinutes: config.delayMinutes || 5,
+                        maxRetries: config.maxRetries || 2,
+                      }
+                      updatedConfig[index] = newConfig as unknown as RetryConfig
                     }
-                    
+
                     onFieldChange('retryConfig', updatedConfig)
                   }}
                 >
@@ -573,6 +584,7 @@ export function RetryConfiguration({ onFieldChange, values }: RetryConfiguration
                     <SelectItem value="sipCode">SIP Code</SelectItem>
                     <SelectItem value="metric">Metric</SelectItem>
                     <SelectItem value="fieldExtractor">Field Extractor</SelectItem>
+                    <SelectItem value="metadata">Metadata</SelectItem>
                   </SelectContent>
                 </Select>
               </div>
@@ -756,6 +768,80 @@ export function RetryConfiguration({ onFieldChange, values }: RetryConfiguration
                           </div>
                         )}
                       </>
+                    )}
+                  </>
+                )}
+
+                {/* Metadata Fields (call-level metadata, e.g. AMD verdict) */}
+                {config.type === 'metadata' && (
+                  <>
+                    <div>
+                      <Label className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-1.5 block">
+                        Metadata Field
+                      </Label>
+                      <Select
+                        value={config.fieldName || CALL_METADATA_FIELDS[0].key}
+                        onValueChange={(value) => {
+                          handleRetryChange(index, 'fieldName', value)
+                        }}
+                      >
+                        <SelectTrigger className="h-9 text-sm">
+                          <SelectValue placeholder="Select field" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {CALL_METADATA_FIELDS.map((field) => (
+                            <SelectItem key={field.key} value={field.key}>
+                              {field.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                        Call-level metadata produced by the voice agent (not agent-configurable, unlike Field Extractor).
+                      </p>
+                    </div>
+
+                    <div>
+                      <Label className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-1.5 block">
+                        Operator
+                      </Label>
+                      <Select
+                        value={config.operator || 'missing'}
+                        onValueChange={(value: 'missing' | 'equals' | 'not_equals' | 'contains' | 'not_contains') => {
+                          handleRetryChange(index, 'operator', value)
+                          if (value === 'missing') {
+                            handleRetryChange(index, 'expectedValue', undefined)
+                          }
+                        }}
+                      >
+                        <SelectTrigger className="h-9 text-sm">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="missing">Missing</SelectItem>
+                          <SelectItem value="equals">Equals</SelectItem>
+                          <SelectItem value="not_equals">Not Equals</SelectItem>
+                          <SelectItem value="contains">Contains</SelectItem>
+                          <SelectItem value="not_contains">Not Contains</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+
+                    {config.operator && (config.operator as string) !== 'missing' && (
+                      <div>
+                        <Label className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-1.5 block">
+                          Expected Value
+                        </Label>
+                        <Input
+                          type="text"
+                          value={config.expectedValue || ''}
+                          onChange={(e) => {
+                            handleRetryChange(index, 'expectedValue', e.target.value)
+                          }}
+                          className="h-9 text-sm"
+                          placeholder="e.g. machine_vm"
+                        />
+                      </div>
                     )}
                   </>
                 )}

--- a/src/utils/campaigns/constants.ts
+++ b/src/utils/campaigns/constants.ts
@@ -153,18 +153,18 @@ export const VALID_SIP_ERROR_CODE_VALUES = VALID_SIP_ERROR_CODES.filter(c => c.e
 
 // Retry Configuration
 export interface RetryConfig {
-  type: 'sipCode' | 'metric' | 'fieldExtractor'
+  type: 'sipCode' | 'metric' | 'fieldExtractor' | 'metadata'
   // For sipCode:
   errorCodes?: string[]  // e.g., ['408', '480', '486']
   // For metric:
   metricName?: string  // e.g., 'sentiment', 'intent', 'customer_satisfaction'
   threshold?: number  // e.g., 0.7, 50, 80
-  // For fieldExtractor:
-  fieldName?: string  // e.g., 'customerName', 'orderId', 'email'
+  // For fieldExtractor and metadata:
+  fieldName?: string  // fieldExtractor: e.g. 'customerName', 'orderId'. metadata: e.g. 'amd-verdict', 'hangup_cause'
   expectedValue?: any  // Optional: value to compare against
-  // Operator can be either metric operator or fieldExtractor operator
+  // Operator can be either metric operator or fieldExtractor/metadata operator
   // Metric operators: '<' | '>' | '<=' | '>=' | '==' | '!='
-  // FieldExtractor operators: 'missing' | 'equals' | 'not_equals' | 'contains' | 'not_contains'
+  // FieldExtractor/metadata operators: 'missing' | 'equals' | 'not_equals' | 'contains' | 'not_contains'
   operator?: '<' | '>' | '<=' | '>=' | '==' | '!=' | 'missing' | 'equals' | 'not_equals' | 'contains' | 'not_contains'
   // Common fields (required for all types):
   delayMinutes: number  // Minutes to wait before retry (0-1440)
@@ -175,6 +175,16 @@ export interface RetryConfig {
   // Length 1-10. Absent / empty = legacy fixed-delay behavior.
   backoffMinutes?: number[]
 }
+
+// Fixed set of call-level metadata keys available for the 'metadata' retry
+// type. Unlike fieldExtractor (whose options come from the agent's
+// field_extractor_prompt), these are produced by the voice agent itself
+// (e.g. LiveKit AMD) and aren't agent-configurable, so the list is static.
+export const CALL_METADATA_FIELDS = [
+  { key: 'amd-verdict', label: 'AMD Verdict (Answering Machine Detection)' },
+  { key: 'hangup_cause', label: 'Hangup Cause' },
+  { key: 'call_ended_reason', label: 'Call Ended Reason' },
+] as const
 
 // Campaign types
 export interface CallStats {

--- a/src/utils/campaigns/constants.ts
+++ b/src/utils/campaigns/constants.ts
@@ -180,11 +180,20 @@ export interface RetryConfig {
 // type. Unlike fieldExtractor (whose options come from the agent's
 // field_extractor_prompt), these are produced by the voice agent itself
 // (e.g. LiveKit AMD) and aren't agent-configurable, so the list is static.
+//
+// `enabled: false` mirrors the SIP-code "coming soon" pattern below —
+// hangup_cause/call_ended_reason are listed for visibility but disabled
+// because nothing currently writes those keys to contact.callMetadata
+// (only amd-verdict is live), so a rule on them would silently never fire.
 export const CALL_METADATA_FIELDS = [
-  { key: 'amd-verdict', label: 'AMD Verdict (Answering Machine Detection)' },
-  { key: 'hangup_cause', label: 'Hangup Cause' },
-  { key: 'call_ended_reason', label: 'Call Ended Reason' },
+  { key: 'amd-verdict', label: 'AMD Verdict (Answering Machine Detection)', enabled: true },
+  { key: 'hangup_cause', label: 'Hangup Cause', enabled: false },
+  { key: 'call_ended_reason', label: 'Call Ended Reason', enabled: false },
 ] as const
+
+// Only enabled keys — this is what the backend validator (schedule/route.ts)
+// actually accepts, same rationale as VALID_SIP_ERROR_CODE_VALUES above.
+export const VALID_CALL_METADATA_FIELD_KEYS = CALL_METADATA_FIELDS.filter(f => f.enabled).map(f => f.key)
 
 // Campaign types
 export interface CallStats {


### PR DESCRIPTION
**Summary**
Adds a 4th retry type — Metadata — to the campaign Retry Configuration UI, letting a user retry a contact based on call-level metadata (e.g. AMD verdict) rather than SIP codes, metric thresholds, or extracted conversation fields.

**What changed**
- constants.ts — widened RetryConfig.type to include 'metadata'; added CALL_METADATA_FIELDS, a fixed list of call-level metadata keys (amd-verdict, hangup_cause, call_ended_reason) since these come from the voice agent itself, not per-agent config.
- RetryConfiguration.tsx — added "Metadata" to the Retry Type selector, with a field dropdown (from CALL_METADATA_FIELDS), operator (missing/equals/not_equals/contains/not_contains), and expected-value input — same shape as the existing Field Extractor UI.
- create/page.tsx — normalizes type: 'metadata' rules in the submit payload.
- api/campaigns/schedule/route.ts — validates metadata rules server-side, restricting fieldName to the known CALL_METADATA_FIELDS list.

**Backward compatibility**
Purely additive — existing sipCode/metric/fieldExtractor rules and their rendering are untouched.