### PR TITLE
ci: only run SonarQube quality gate on pull_request events

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,6 +96,11 @@ jobs:
     name: SonarQube Scan & Quality Gate
     runs-on: ubuntu-latest
     needs: test
+    # Community Edition has no real branch-analysis support, so a push-triggered
+    # run (no PR context) scans the whole codebase against absolute conditions
+    # instead of the PR diff, and can fail for reasons unrelated to the PR —
+    # only run this job for pull_request, where the scan is scoped to the diff.
+    if: github.event_name == 'pull_request'
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4


### PR DESCRIPTION
Push-triggered runs of the sonarqube job have no PR context, so the scan falls back to a whole-branch analysis evaluated against absolute conditions instead of the PR diff — this can fail (as it did on PR #535) for reasons unrelated to the PR being merged, while sharing the same required check name as the correct PR-scoped scan and blocking merges.

Scopes the job to `pull_request` events only, since that's the only context where the scan is meaningful for gating a merge.