### PR TITLE
Migrate ElevenLabs voice routes to India data residency

### DIFF
--- a/src/app/api/elevenlabs-preview/route.ts
+++ b/src/app/api/elevenlabs-preview/route.ts
@@ -12,8 +12,9 @@ export async function POST(request: NextRequest) {
 
     // Use eleven_flash_v2_5 — the same model used in production agents,
     // supports all languages and is low-latency.
+    // India residency migration — one-way move, no dual-region support needed.
     const response = await fetch(
-      `https://api.elevenlabs.io/v1/text-to-speech/${voice_id}`,
+      `https://api.in.residency.elevenlabs.io/v1/text-to-speech/${voice_id}`,
       {
         method: 'POST',
         headers: {

--- a/src/app/api/elevenlabs-voices/route.ts
+++ b/src/app/api/elevenlabs-voices/route.ts
@@ -12,7 +12,8 @@ export async function GET(request: NextRequest) {
       )
     }
     
-    const response = await fetch('https://api.elevenlabs.io/v1/voices', {
+    // India residency migration — one-way move, no dual-region support needed.
+    const response = await fetch('https://api.in.residency.elevenlabs.io/v1/voices', {
       method: 'GET',
       headers: {
         'xi-api-key': apiKey,


### PR DESCRIPTION
Points the 2 ElevenLabs API calls to the India residency endpoint
(api.in.residency.elevenlabs.io) instead of the default US one.

Changes:
- elevenlabs-voices/route.ts: voice list fetch → India URL
- elevenlabs-preview/route.ts: voice preview TTS fetch → India URL

One-way move, no dual-region flag.

Verified:
- No other ElevenLabs API call sites in the repo (grepped clean)
- TypeScript check clean on both changed files (unrelated pre-existing