### PR TITLE
Make call logs manual filters and Period filter act independently

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -92,32 +92,30 @@ const formatShort = (date: Date) =>
 // counterparts. When `locked` (manual filters active on the Logs tab), the button
 // always renders in its plain/unselected look so it never appears chosen or
 // interactive, regardless of which period is actually active underneath.
-const periodPillClass = (active: boolean, locked: boolean) =>
-  locked
-    ? 'text-gray-400 dark:text-gray-600'
-    : active
-      ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm'
-      : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-white/50 dark:hover:bg-gray-700/50'
+const periodPillClass = (active: boolean, locked: boolean) => {
+  if (locked) return 'text-gray-400 dark:text-gray-600'
+  if (active) return 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm'
+  return 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-white/50 dark:hover:bg-gray-700/50'
+}
 
-const periodCustomPillClass = (active: boolean, locked: boolean) =>
-  locked
-    ? 'text-gray-400 dark:text-gray-600'
-    : active
-      ? 'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300 border-blue-200 dark:border-blue-800 hover:bg-blue-100 dark:hover:bg-blue-900/30'
-      : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-800'
+const periodCustomPillClass = (active: boolean, locked: boolean) => {
+  if (locked) return 'text-gray-400 dark:text-gray-600'
+  if (active) return 'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300 border-blue-200 dark:border-blue-800 hover:bg-blue-100 dark:hover:bg-blue-900/30'
+  return 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-800'
+}
 
-const periodMobilePillClass = (active: boolean, locked: boolean) =>
-  !locked && active
-    ? 'bg-blue-500 text-white'
-    : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-gray-600'
+const periodMobilePillClass = (active: boolean, locked: boolean) => {
+  if (!locked && active) return 'bg-blue-500 text-white'
+  return 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-gray-600'
+}
 
 const PERIOD_LOCKED_MESSAGE = 'Clear the manual filter to use Period'
 
 interface PeriodOptionButtonProps {
-  onClick: () => void
-  disabled: boolean
-  className: string
-  children: React.ReactNode
+  readonly onClick: () => void
+  readonly disabled: boolean
+  readonly className: string
+  readonly children: React.ReactNode
 }
 
 // A Period quick-filter button. When disabled, wraps itself in a Tooltip explaining
@@ -135,7 +133,7 @@ function PeriodOptionButton({ onClick, disabled, className, children }: PeriodOp
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span tabIndex={0} className="inline-flex">{button}</span>
+        <span role="button" aria-disabled="true" tabIndex={0} className="inline-flex">{button}</span>
       </TooltipTrigger>
       <TooltipContent>{PERIOD_LOCKED_MESSAGE}</TooltipContent>
     </Tooltip>
@@ -752,7 +750,7 @@ const { data: callsCheck, isLoading: callsCheckLoading } = useSupabaseQuery(
                       {isPeriodLocked ? (
                         <Tooltip>
                           <TooltipTrigger asChild>
-                            <span tabIndex={0} className="inline-flex">
+                            <span role="button" aria-disabled="true" tabIndex={0} className="inline-flex">
                               <Button
                                 variant="outline"
                                 size="sm"
@@ -907,7 +905,7 @@ const { data: callsCheck, isLoading: callsCheckLoading } = useSupabaseQuery(
                   {isPeriodLocked ? (
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <span tabIndex={0} className="inline-flex">
+                        <span role="button" aria-disabled="true" tabIndex={0} className="inline-flex">
                           <button
                             disabled
                             className={`px-3 py-1.5 text-sm font-medium rounded-md transition-all flex items-center gap-1.5 disabled:opacity-50 disabled:pointer-events-none ${periodMobilePillClass(isCustomRange, true)}`}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -7,6 +7,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { Badge } from '@/components/ui/badge'
 import { Calendar } from '@/components/ui/calendar'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import {
   ChevronLeft,
   BarChart3,
@@ -87,6 +88,60 @@ const formatDateISO = (date: Date): string => {
 const formatShort = (date: Date) =>
   date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
 
+// Period control styling — shared by the desktop pill buttons and their mobile
+// counterparts. When `locked` (manual filters active on the Logs tab), the button
+// always renders in its plain/unselected look so it never appears chosen or
+// interactive, regardless of which period is actually active underneath.
+const periodPillClass = (active: boolean, locked: boolean) =>
+  locked
+    ? 'text-gray-400 dark:text-gray-600'
+    : active
+      ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm'
+      : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-white/50 dark:hover:bg-gray-700/50'
+
+const periodCustomPillClass = (active: boolean, locked: boolean) =>
+  locked
+    ? 'text-gray-400 dark:text-gray-600'
+    : active
+      ? 'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300 border-blue-200 dark:border-blue-800 hover:bg-blue-100 dark:hover:bg-blue-900/30'
+      : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-800'
+
+const periodMobilePillClass = (active: boolean, locked: boolean) =>
+  !locked && active
+    ? 'bg-blue-500 text-white'
+    : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-gray-600'
+
+const PERIOD_LOCKED_MESSAGE = 'Clear the manual filter to use Period'
+
+interface PeriodOptionButtonProps {
+  onClick: () => void
+  disabled: boolean
+  className: string
+  children: React.ReactNode
+}
+
+// A Period quick-filter button. When disabled, wraps itself in a Tooltip explaining
+// why — native `disabled` buttons don't fire hover events in most browsers, so the
+// tooltip trigger is a span around the button rather than the button itself.
+function PeriodOptionButton({ onClick, disabled, className, children }: PeriodOptionButtonProps) {
+  const button = (
+    <button onClick={onClick} disabled={disabled} className={className}>
+      {children}
+    </button>
+  )
+
+  if (!disabled) return button
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span tabIndex={0} className="inline-flex">{button}</span>
+      </TooltipTrigger>
+      <TooltipContent>{PERIOD_LOCKED_MESSAGE}</TooltipContent>
+    </Tooltip>
+  )
+}
+
 // Component for skeleton when agent data is loading
 // Simple No Calls component for VAPI agents
 function NoCallsMessage() {
@@ -136,7 +191,7 @@ const Dashboard: React.FC<DashboardProps> = ({ agentId }) => {
   const [connectingRetellWebhook, setConnectingRetellWebhook] = useState(false)
   
   // Date filter state — stored in Zustand (persisted) so it survives navigation.
-  const { dateFilterByAgent, setDateFilterForAgent } = useCallLogsStore()
+  const { dateFilterByAgent, setDateFilterForAgent, filtersByAgent } = useCallLogsStore()
   const storedDateFilter = dateFilterByAgent[agentId] ?? DEFAULT_DATE_FILTER
 
   const quickFilter   = storedDateFilter.quickFilter
@@ -155,8 +210,19 @@ const Dashboard: React.FC<DashboardProps> = ({ agentId }) => {
    
   }, [quickFilter, isCustomRange, storedDateFilter.dateFrom, storedDateFilter.dateTo])
 
+  // Label shown on the Custom-range trigger — shared by the desktop and mobile controls.
+  const customRangeLabel = isCustomRange && dateRange.from && dateRange.to
+    ? `${formatShort(dateRange.from)} – ${formatShort(dateRange.to)}`
+    : 'Custom'
+
   const activeTab = searchParams.get('tab') || 'overview'
   const openDownloadSettings = searchParams.get('openDownloadSettings') === '1'
+
+  // The Period control is shared between Overview and Logs, but the two filters must
+  // act independently (see useCallLogsData). While a manual filter is active on the
+  // Logs tab, lock Period so it can't be changed there — Overview is unaffected since
+  // this only engages for activeTab === 'logs'.
+  const isPeriodLocked = activeTab === 'logs' && (filtersByAgent[agentId]?.length ?? 0) > 0
   
   const quickFilters = [
     { id: '1d', label: '1D', days: 1 },
@@ -267,6 +333,7 @@ const { data: callsCheck, isLoading: callsCheckLoading } = useSupabaseQuery(
 
   // Date filter handlers — write to Zustand store (persisted across navigation)
   const handleQuickFilter = (filterId: string) => {
+    if (isPeriodLocked) return
     setDateFilterForAgent(agentId, {
       quickFilter: filterId,
       isCustomRange: false,
@@ -278,6 +345,7 @@ const { data: callsCheck, isLoading: callsCheckLoading } = useSupabaseQuery(
   }
 
   const handleDateRangeSelect = (range: DateRange | undefined) => {
+    if (isPeriodLocked) return
     if (range?.from && range?.to) {
       setDateFilterForAgent(agentId, {
         quickFilter: '',
@@ -670,50 +738,59 @@ const { data: callsCheck, isLoading: callsCheckLoading } = useSupabaseQuery(
                       <span className="text-sm font-medium text-gray-600 dark:text-gray-400">Period</span>
                       <div className="flex items-center gap-1 bg-gray-100 dark:bg-gray-800 rounded-lg p-1">
                         {quickFilters.map((filter) => (
-                          <button
+                          <PeriodOptionButton
                             key={filter.id}
                             onClick={() => handleQuickFilter(filter.id)}
-                            className={`px-4 py-2 text-sm font-medium rounded-md transition-all duration-200 ${
-                              quickFilter === filter.id && !isCustomRange
-                                ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm'
-                                : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-white/50 dark:hover:bg-gray-700/50'
-                            }`}
+                            disabled={isPeriodLocked}
+                            className={`px-4 py-2 text-sm font-medium rounded-md transition-all duration-200 disabled:opacity-50 disabled:pointer-events-none ${periodPillClass(quickFilter === filter.id && !isCustomRange, isPeriodLocked)}`}
                           >
                             {filter.label}
-                          </button>
+                          </PeriodOptionButton>
                         ))}
                       </div>
-                      
-                      <Popover>
-                        <PopoverTrigger asChild>
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            className={`px-4 py-2 text-sm font-medium rounded-lg border-gray-200 dark:border-gray-700 transition-all duration-200 ${
-                              isCustomRange 
-                                ? 'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300 border-blue-200 dark:border-blue-800 hover:bg-blue-100 dark:hover:bg-blue-900/30' 
-                                : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-800'
-                            }`}
-                          >
-                            <CalendarDays className="mr-2 h-4 w-4 shrink-0" />
-                            {isCustomRange && dateRange.from && dateRange.to
-                              ? `${formatShort(dateRange.from)} – ${formatShort(dateRange.to)}`
-                              : 'Custom'
-                            }
-                          </Button>
-                        </PopoverTrigger>
-                        <PopoverContent className="w-auto p-0 border-gray-200 dark:border-gray-700 shadow-xl rounded-xl" align="end">
-                          <Calendar
-                            initialFocus
-                            mode="range"
-                            defaultMonth={dateRange?.from}
-                            selected={dateRange}
-                            onSelect={handleDateRangeSelect}
-                            numberOfMonths={2}
-                            className="rounded-xl"
-                          />
-                        </PopoverContent>
-                      </Popover>
+
+                      {isPeriodLocked ? (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span tabIndex={0} className="inline-flex">
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                disabled
+                                className={`px-4 py-2 text-sm font-medium rounded-lg border-gray-200 dark:border-gray-700 transition-all duration-200 ${periodCustomPillClass(isCustomRange, true)}`}
+                              >
+                                <CalendarDays className="mr-2 h-4 w-4 shrink-0" />
+                                {customRangeLabel}
+                              </Button>
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent>{PERIOD_LOCKED_MESSAGE}</TooltipContent>
+                        </Tooltip>
+                      ) : (
+                        <Popover>
+                          <PopoverTrigger asChild>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              className={`px-4 py-2 text-sm font-medium rounded-lg border-gray-200 dark:border-gray-700 transition-all duration-200 ${periodCustomPillClass(isCustomRange, false)}`}
+                            >
+                              <CalendarDays className="mr-2 h-4 w-4 shrink-0" />
+                              {customRangeLabel}
+                            </Button>
+                          </PopoverTrigger>
+                          <PopoverContent className="w-auto p-0 border-gray-200 dark:border-gray-700 shadow-xl rounded-xl" align="end">
+                            <Calendar
+                              initialFocus
+                              mode="range"
+                              defaultMonth={dateRange?.from}
+                              selected={dateRange}
+                              onSelect={handleDateRangeSelect}
+                              numberOfMonths={2}
+                              className="rounded-xl"
+                            />
+                          </PopoverContent>
+                        </Popover>
+                      )}
                     </div>
                     
                     {/* Field Extractor & Metrics - skeleton while agent loading; visibility-controlled */}
@@ -817,46 +894,53 @@ const { data: callsCheck, isLoading: callsCheckLoading } = useSupabaseQuery(
                 <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wide">Period</div>
                 <div className="flex flex-wrap gap-2">
                   {quickFilters.map((filter) => (
-                    <button
+                    <PeriodOptionButton
                       key={filter.id}
                       onClick={() => handleQuickFilter(filter.id)}
-                      className={`px-3 py-1.5 text-sm font-medium rounded-md transition-all ${
-                        quickFilter === filter.id && !isCustomRange
-                          ? 'bg-blue-500 text-white'
-                          : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-gray-600'
-                      }`}
+                      disabled={isPeriodLocked}
+                      className={`px-3 py-1.5 text-sm font-medium rounded-md transition-all disabled:opacity-50 disabled:pointer-events-none ${periodMobilePillClass(quickFilter === filter.id && !isCustomRange, isPeriodLocked)}`}
                     >
                       {filter.label}
-                    </button>
+                    </PeriodOptionButton>
                   ))}
-                  
-                  <Popover>
-                    <PopoverTrigger asChild>
-                      <button
-                        className={`px-3 py-1.5 text-sm font-medium rounded-md transition-all flex items-center gap-1.5 ${
-                          isCustomRange 
-                            ? 'bg-blue-500 text-white'
-                            : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-gray-600'
-                        }`}
-                      >
-                        <CalendarDays className="h-3 w-3 shrink-0" />
-                        {isCustomRange && dateRange.from && dateRange.to
-                          ? `${formatShort(dateRange.from)} – ${formatShort(dateRange.to)}`
-                          : 'Custom'
-                        }
-                      </button>
-                    </PopoverTrigger>
-                    <PopoverContent className="w-auto p-0" align="end">
-                      <Calendar
-                        initialFocus
-                        mode="range"
-                        defaultMonth={dateRange?.from}
-                        selected={dateRange}
-                        onSelect={handleDateRangeSelect}
-                        numberOfMonths={1}
-                      />
-                    </PopoverContent>
-                  </Popover>
+
+                  {isPeriodLocked ? (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span tabIndex={0} className="inline-flex">
+                          <button
+                            disabled
+                            className={`px-3 py-1.5 text-sm font-medium rounded-md transition-all flex items-center gap-1.5 disabled:opacity-50 disabled:pointer-events-none ${periodMobilePillClass(isCustomRange, true)}`}
+                          >
+                            <CalendarDays className="h-3 w-3 shrink-0" />
+                            {customRangeLabel}
+                          </button>
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>{PERIOD_LOCKED_MESSAGE}</TooltipContent>
+                    </Tooltip>
+                  ) : (
+                    <Popover>
+                      <PopoverTrigger asChild>
+                        <button
+                          className={`px-3 py-1.5 text-sm font-medium rounded-md transition-all flex items-center gap-1.5 ${periodMobilePillClass(isCustomRange, false)}`}
+                        >
+                          <CalendarDays className="h-3 w-3 shrink-0" />
+                          {customRangeLabel}
+                        </button>
+                      </PopoverTrigger>
+                      <PopoverContent className="w-auto p-0" align="end">
+                        <Calendar
+                          initialFocus
+                          mode="range"
+                          defaultMonth={dateRange?.from}
+                          selected={dateRange}
+                          onSelect={handleDateRangeSelect}
+                          numberOfMonths={1}
+                        />
+                      </PopoverContent>
+                    </Popover>
+                  )}
                 </div>
               </div>
 

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -118,22 +118,26 @@ interface PeriodOptionButtonProps {
   readonly children: React.ReactNode
 }
 
-// A Period quick-filter button. When disabled, wraps itself in a Tooltip explaining
-// why — native `disabled` buttons don't fire hover events in most browsers, so the
-// tooltip trigger is a span around the button rather than the button itself.
+// A Period quick-filter button. When disabled, it stays a real <button> (marked
+// `aria-disabled` rather than the native `disabled` attribute) and doubles as its
+// own Tooltip trigger — a native `disabled` button won't fire the hover/focus
+// events a Tooltip needs, but `aria-disabled` keeps it interactive for that
+// purpose while onClick still no-ops via the caller's own guard.
 function PeriodOptionButton({ onClick, disabled, className, children }: PeriodOptionButtonProps) {
-  const button = (
-    <button onClick={onClick} disabled={disabled} className={className}>
-      {children}
-    </button>
-  )
-
-  if (!disabled) return button
+  if (!disabled) {
+    return (
+      <button onClick={onClick} className={className}>
+        {children}
+      </button>
+    )
+  }
 
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span role="button" aria-disabled="true" tabIndex={0} className="inline-flex">{button}</span>
+        <button type="button" aria-disabled="true" onClick={onClick} className={className}>
+          {children}
+        </button>
       </TooltipTrigger>
       <TooltipContent>{PERIOD_LOCKED_MESSAGE}</TooltipContent>
     </Tooltip>
@@ -740,7 +744,7 @@ const { data: callsCheck, isLoading: callsCheckLoading } = useSupabaseQuery(
                             key={filter.id}
                             onClick={() => handleQuickFilter(filter.id)}
                             disabled={isPeriodLocked}
-                            className={`px-4 py-2 text-sm font-medium rounded-md transition-all duration-200 disabled:opacity-50 disabled:pointer-events-none ${periodPillClass(quickFilter === filter.id && !isCustomRange, isPeriodLocked)}`}
+                            className={`px-4 py-2 text-sm font-medium rounded-md transition-all duration-200 aria-disabled:opacity-50 aria-disabled:cursor-not-allowed ${periodPillClass(quickFilter === filter.id && !isCustomRange, isPeriodLocked)}`}
                           >
                             {filter.label}
                           </PeriodOptionButton>
@@ -750,17 +754,15 @@ const { data: callsCheck, isLoading: callsCheckLoading } = useSupabaseQuery(
                       {isPeriodLocked ? (
                         <Tooltip>
                           <TooltipTrigger asChild>
-                            <span role="button" aria-disabled="true" tabIndex={0} className="inline-flex">
-                              <Button
-                                variant="outline"
-                                size="sm"
-                                disabled
-                                className={`px-4 py-2 text-sm font-medium rounded-lg border-gray-200 dark:border-gray-700 transition-all duration-200 ${periodCustomPillClass(isCustomRange, true)}`}
-                              >
-                                <CalendarDays className="mr-2 h-4 w-4 shrink-0" />
-                                {customRangeLabel}
-                              </Button>
-                            </span>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              aria-disabled="true"
+                              className={`px-4 py-2 text-sm font-medium rounded-lg border-gray-200 dark:border-gray-700 transition-all duration-200 aria-disabled:opacity-50 aria-disabled:cursor-not-allowed ${periodCustomPillClass(isCustomRange, true)}`}
+                            >
+                              <CalendarDays className="mr-2 h-4 w-4 shrink-0" />
+                              {customRangeLabel}
+                            </Button>
                           </TooltipTrigger>
                           <TooltipContent>{PERIOD_LOCKED_MESSAGE}</TooltipContent>
                         </Tooltip>
@@ -896,7 +898,7 @@ const { data: callsCheck, isLoading: callsCheckLoading } = useSupabaseQuery(
                       key={filter.id}
                       onClick={() => handleQuickFilter(filter.id)}
                       disabled={isPeriodLocked}
-                      className={`px-3 py-1.5 text-sm font-medium rounded-md transition-all disabled:opacity-50 disabled:pointer-events-none ${periodMobilePillClass(quickFilter === filter.id && !isCustomRange, isPeriodLocked)}`}
+                      className={`px-3 py-1.5 text-sm font-medium rounded-md transition-all aria-disabled:opacity-50 aria-disabled:cursor-not-allowed ${periodMobilePillClass(quickFilter === filter.id && !isCustomRange, isPeriodLocked)}`}
                     >
                       {filter.label}
                     </PeriodOptionButton>
@@ -905,15 +907,14 @@ const { data: callsCheck, isLoading: callsCheckLoading } = useSupabaseQuery(
                   {isPeriodLocked ? (
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <span role="button" aria-disabled="true" tabIndex={0} className="inline-flex">
-                          <button
-                            disabled
-                            className={`px-3 py-1.5 text-sm font-medium rounded-md transition-all flex items-center gap-1.5 disabled:opacity-50 disabled:pointer-events-none ${periodMobilePillClass(isCustomRange, true)}`}
-                          >
-                            <CalendarDays className="h-3 w-3 shrink-0" />
-                            {customRangeLabel}
-                          </button>
-                        </span>
+                        <button
+                          type="button"
+                          aria-disabled="true"
+                          className={`px-3 py-1.5 text-sm font-medium rounded-md transition-all flex items-center gap-1.5 aria-disabled:opacity-50 aria-disabled:cursor-not-allowed ${periodMobilePillClass(isCustomRange, true)}`}
+                        >
+                          <CalendarDays className="h-3 w-3 shrink-0" />
+                          {customRangeLabel}
+                        </button>
                       </TooltipTrigger>
                       <TooltipContent>{PERIOD_LOCKED_MESSAGE}</TooltipContent>
                     </Tooltip>

--- a/src/hooks/useCallLogsData.ts
+++ b/src/hooks/useCallLogsData.ts
@@ -57,6 +57,11 @@ export const useCallLogsData = (
     [activeFilters, agentId]
   )
 
+  // The Period (date range) filter and manually-added filters must act independently:
+  // once the user adds a manual filter, the Period filter is excluded from the query
+  // entirely rather than being ANDed with it.
+  const effectiveDateRange = activeFilters.length > 0 ? undefined : dateRange
+
   useEffect(() => {
     if ((userEmail || userId) && projectId) {
       const getUserRole = async () => {
@@ -92,13 +97,13 @@ export const useCallLogsData = (
   const filterKey = JSON.stringify(activeFilters)
   const prevQueryKeyRef = useRef<string>('')
   useEffect(() => {
-    const key = `${agentId}|${filterKey}|${dateRange?.from}|${dateRange?.to}`
+    const key = `${agentId}|${filterKey}|${effectiveDateRange?.from}|${effectiveDateRange?.to}`
     if (prevQueryKeyRef.current && prevQueryKeyRef.current !== key) {
       setCurrentPage(1)
     }
     prevQueryKeyRef.current = key
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [agentId, filterKey, dateRange?.from, dateRange?.to])
+  }, [agentId, filterKey, effectiveDateRange?.from, effectiveDateRange?.to])
 
   // ── Per-page query (direct offset fetch — no sequential loading) ──────────
   const queryEnabled = !!agentId && !roleLoading
@@ -116,7 +121,7 @@ export const useCallLogsData = (
     postDistinctFilters,
     select: selectColumns,
     distinctConfig,
-    dateRange,
+    dateRange: effectiveDateRange,
     page: currentPage,
     enabled: queryEnabled,
     refetchOnMount: false,
@@ -177,7 +182,7 @@ export const useCallLogsData = (
       selectColumns,
       { column: 'created_at', ascending: false },
       distinctConfig,
-      dateRange,
+      effectiveDateRange,
       userId ?? 'no-user',
       nextPage,
     )
@@ -196,8 +201,8 @@ export const useCallLogsData = (
           p_distinct_column: distinctConfig?.column || null,
           p_distinct_json_field: distinctConfig?.jsonField || null,
           p_distinct_order: distinctConfig?.order || 'asc',
-          p_date_from: dateRange?.from || null,
-          p_date_to: dateRange?.to || null,
+          p_date_from: effectiveDateRange?.from || null,
+          p_date_to: effectiveDateRange?.to || null,
           p_user_clerk_id: userId || null,
           p_user_email: userEmail || null,
         }


### PR DESCRIPTION
## Summary
- Call logs query now ignores the Period (date range) filter whenever a manual filter is applied, instead of ANDing both together (`useCallLogsData.ts`).
- Period control is locked (disabled, flat/faded, no hover) while a manual filter is active on the Logs tab, with a tooltip explaining why. Overview's Period control is unaffected.

## Why
Previously, adding a manual filter in Call Logs still had the Period filter applied on top, silently narrowing results in a way that wasn't obvious to the user.