### PR TITLE
feat: add Real Interruption Guard toggle to agent interruption settings

### DIFF
--- a/src/app/api/agents/save-and-deploy/route.ts
+++ b/src/app/api/agents/save-and-deploy/route.ts
@@ -543,6 +543,7 @@ function transformFormDataToAgentConfig(formData: any) {
           },
           interruption_mode: formikValues.advancedSettings.session.interruption_mode ?? null,
           adaptive_stt: formikValues.advancedSettings.session.interruption_mode === 'adaptive',
+          real_interruption_guard: formikValues.advancedSettings.interruption.realInterruptionGuard ?? false,
           ...buildRouteAdaptiveInterruptionPayload(formikValues),
           first_message_mode: firstMessageModeConfig
         }

--- a/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/InterruptionSettings.tsx
+++ b/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/InterruptionSettings.tsx
@@ -117,23 +117,6 @@ function InterruptionSettings({
 
       {allowInterruptions && (
         <>
-          {/* Real Interruption Guard */}
-          <div className="flex items-center justify-between">
-            <div className="pr-4">
-              <Label className="text-xs font-medium text-gray-700 dark:text-gray-300">
-                Real Interruption Guard (Beta)
-              </Label>
-              <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-                Filters out backchannels/false interruptions before cancelling agent speech. Turn Detection recommended "V1 Mini".
-              </div>
-            </div>
-            <Switch
-              checked={realInterruptionGuard}
-              onCheckedChange={(checked) => onFieldChange('advancedSettings.interruption.realInterruptionGuard', checked)}
-              className="scale-75"
-            />
-          </div>
-
           {/* Interruption Mode — segmented control */}
           <div className="space-y-2">
             <Label className="text-xs font-medium text-gray-700 dark:text-gray-300">
@@ -214,6 +197,23 @@ function InterruptionSettings({
                   value={minInterruptionWords}
                   onChange={(e) => onFieldChange('advancedSettings.interruption.minInterruptionWords', parseInt(e.target.value) || 0)}
                   className="h-7 text-xs"
+                />
+              </div>
+
+              {/* Real Interruption Guard — VAD mode only, conflicts with adaptive's own ML detector */}
+              <div className="flex items-center justify-between">
+                <div className="pr-4">
+                  <Label className="text-xs font-medium text-gray-700 dark:text-gray-300">
+                    Real Interruption Guard (Beta)
+                  </Label>
+                  <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                    Filters out backchannels/false interruptions before cancelling agent speech. Turn Detection recommended "V1 Mini".
+                  </div>
+                </div>
+                <Switch
+                  checked={realInterruptionGuard}
+                  onCheckedChange={(checked) => onFieldChange('advancedSettings.interruption.realInterruptionGuard', checked)}
+                  className="scale-75"
                 />
               </div>
             </>

--- a/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/InterruptionSettings.tsx
+++ b/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/InterruptionSettings.tsx
@@ -32,6 +32,7 @@ interface InterruptionSettingsProps {
   adaptiveFalseInterruptionTimeout?: number
   adaptiveBackchannelBoundaryStart?: number
   adaptiveBackchannelBoundaryEnd?: number
+  realInterruptionGuard?: boolean
   onFieldChange: (field: string, value: any) => void
 }
 
@@ -50,6 +51,7 @@ function InterruptionSettings({
   adaptiveFalseInterruptionTimeout = 2.0,
   adaptiveBackchannelBoundaryStart = 1.0,
   adaptiveBackchannelBoundaryEnd = 3.5,
+  realInterruptionGuard = false,
   onFieldChange
 }: InterruptionSettingsProps) {
   const [newWord, setNewWord] = useState('')
@@ -115,6 +117,23 @@ function InterruptionSettings({
 
       {allowInterruptions && (
         <>
+          {/* Real Interruption Guard */}
+          <div className="flex items-center justify-between">
+            <div className="pr-4">
+              <Label className="text-xs font-medium text-gray-700 dark:text-gray-300">
+                Real Interruption Guard (Beta)
+              </Label>
+              <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                Filters out backchannels/false interruptions before cancelling agent speech. Turn Detection recommended "V1 Mini".
+              </div>
+            </div>
+            <Switch
+              checked={realInterruptionGuard}
+              onCheckedChange={(checked) => onFieldChange('advancedSettings.interruption.realInterruptionGuard', checked)}
+              className="scale-75"
+            />
+          </div>
+
           {/* Interruption Mode — segmented control */}
           <div className="space-y-2">
             <Label className="text-xs font-medium text-gray-700 dark:text-gray-300">

--- a/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/SessionBehaviourSettings.tsx
+++ b/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/SessionBehaviourSettings.tsx
@@ -7,7 +7,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 
 interface SessionBehaviourSettingsProps {
   preemptiveGeneration: 'enabled' | 'disabled'
-  turn_detection: 'multilingual' | 'english' | 'smollm2turndetector' | 'llmturndetector' | 'smollm360m' | 'disabled'
+  turn_detection: 'multilingual' | 'english' | 'smollm2turndetector' | 'llmturndetector' | 'smollm360m' | 'disabled' | 'v1-mini'
   unlikely_threshold?: number
   min_endpointing_delay?: number
   max_endpointing_delay?: number
@@ -205,6 +205,7 @@ export default function SessionBehaviourSettings({
               <SelectItem value="smollm2turndetector" className="text-xs">SmolLM2 Turn Detector</SelectItem>
               <SelectItem value="llmturndetector" className="text-xs">LLM Turn Detector</SelectItem>
               <SelectItem value="smollm360m" className="text-xs">SmolLM360M</SelectItem>
+              <SelectItem value="v1-mini" className="text-xs">V1 Mini (Real Interruption Classifier)</SelectItem>
               <SelectItem value="disabled" className="text-xs">Disabled</SelectItem>
             </SelectContent>
           </Select>

--- a/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/SessionBehaviourSettings.tsx
+++ b/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/SessionBehaviourSettings.tsx
@@ -7,7 +7,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 
 interface SessionBehaviourSettingsProps {
   preemptiveGeneration: 'enabled' | 'disabled'
-  turn_detection: 'multilingual' | 'english' | 'smollm2turndetector' | 'llmturndetector' | 'smollm360m' | 'disabled' | 'v1-mini'
+  turn_detection: 'multilingual' | 'english' | 'disabled' | 'v1-mini'
   unlikely_threshold?: number
   min_endpointing_delay?: number
   max_endpointing_delay?: number
@@ -202,9 +202,6 @@ export default function SessionBehaviourSettings({
             <SelectContent>
               <SelectItem value="multilingual" className="text-xs">Multilingual</SelectItem>
               <SelectItem value="english" className="text-xs">English</SelectItem>
-              <SelectItem value="smollm2turndetector" className="text-xs">SmolLM2 Turn Detector</SelectItem>
-              <SelectItem value="llmturndetector" className="text-xs">LLM Turn Detector</SelectItem>
-              <SelectItem value="smollm360m" className="text-xs">SmolLM360M</SelectItem>
               <SelectItem value="v1-mini" className="text-xs">V1 Mini (Real Interruption Classifier)</SelectItem>
               <SelectItem value="disabled" className="text-xs">Disabled</SelectItem>
             </SelectContent>

--- a/src/components/agents/AgentConfig/AgentAdvancedSettings/index.tsx
+++ b/src/components/agents/AgentConfig/AgentAdvancedSettings/index.tsx
@@ -36,6 +36,7 @@ interface AgentAdvancedSettingsProps {
         adaptiveFalseInterruptionTimeout?: number
         adaptiveBackchannelBoundaryStart?: number
         adaptiveBackchannelBoundaryEnd?: number
+        realInterruptionGuard?: boolean
       }
       vad: {
         vadProvider: string
@@ -49,7 +50,7 @@ interface AgentAdvancedSettingsProps {
       }
       session: {
         preemptiveGeneration: 'enabled' | 'disabled'
-        turn_detection: 'multilingual' | 'english' | 'smollm2turndetector' | 'llmturndetector' | 'smollm360m' | 'disabled'
+        turn_detection: 'multilingual' | 'english' | 'smollm2turndetector' | 'llmturndetector' | 'smollm360m' | 'disabled' | 'v1-mini'
         unlikely_threshold?: number
         min_endpointing_delay?: number
         max_endpointing_delay?: number
@@ -198,6 +199,7 @@ function AgentAdvancedSettings({ advancedSettings, onFieldChange, onWebhookDataL
               adaptiveFalseInterruptionTimeout={advancedSettings.interruption.adaptiveFalseInterruptionTimeout ?? 2.0}
               adaptiveBackchannelBoundaryStart={advancedSettings.interruption.adaptiveBackchannelBoundaryStart ?? 1.0}
               adaptiveBackchannelBoundaryEnd={advancedSettings.interruption.adaptiveBackchannelBoundaryEnd ?? 3.5}
+              realInterruptionGuard={advancedSettings.interruption.realInterruptionGuard ?? false}
               onFieldChange={onFieldChange}
             />
           </CollapsibleContent>

--- a/src/components/agents/AgentConfig/AgentAdvancedSettings/index.tsx
+++ b/src/components/agents/AgentConfig/AgentAdvancedSettings/index.tsx
@@ -50,7 +50,7 @@ interface AgentAdvancedSettingsProps {
       }
       session: {
         preemptiveGeneration: 'enabled' | 'disabled'
-        turn_detection: 'multilingual' | 'english' | 'smollm2turndetector' | 'llmturndetector' | 'smollm360m' | 'disabled' | 'v1-mini'
+        turn_detection: 'multilingual' | 'english' | 'disabled' | 'v1-mini'
         unlikely_threshold?: number
         min_endpointing_delay?: number
         max_endpointing_delay?: number

--- a/src/config/agentDefaults.ts
+++ b/src/config/agentDefaults.ts
@@ -227,6 +227,7 @@ export const AGENT_DEFAULT_CONFIG = {
         adaptiveFalseInterruptionTimeout: 2.0,
         adaptiveBackchannelBoundaryStart: 1.0,
         adaptiveBackchannelBoundaryEnd: 3.5,
+        realInterruptionGuard: false,
       },
       vad: {
         vadProvider: AGENT_DEFAULT_CONFIG.vad.name,

--- a/src/config/agentDefaults.ts
+++ b/src/config/agentDefaults.ts
@@ -241,7 +241,7 @@ export const AGENT_DEFAULT_CONFIG = {
       },
       session: {
         preemptiveGeneration: AGENT_DEFAULT_CONFIG.session_behavior.preemptive_generation as "disabled" | "enabled",
-        turn_detection: AGENT_DEFAULT_CONFIG.session_behavior.turn_detection as "multilingual" | "english" | "smollm2turndetector" | "llmturndetector" | "smollm360m" | "disabled",
+        turn_detection: AGENT_DEFAULT_CONFIG.session_behavior.turn_detection as "multilingual" | "english" | "disabled",
         unlikely_threshold: AGENT_DEFAULT_CONFIG.session_behavior.unlikely_threshold,
         min_endpointing_delay: AGENT_DEFAULT_CONFIG.session_behavior.min_endpointing_delay,
         max_endpointing_delay: AGENT_DEFAULT_CONFIG.session_behavior.max_endpointing_delay,

--- a/src/hooks/useAgentConfig.ts
+++ b/src/hooks/useAgentConfig.ts
@@ -840,6 +840,7 @@ export const buildFormValuesFromAgent = (assistant: any) => {
         adaptiveFalseInterruptionTimeout: assistant.adaptive_false_interruption_timeout ?? 2.0,
         adaptiveBackchannelBoundaryStart: assistant.adaptive_backchannel_boundary_start ?? 1.0,
         adaptiveBackchannelBoundaryEnd: assistant.adaptive_backchannel_boundary_end ?? 3.5,
+        realInterruptionGuard: assistant.real_interruption_guard ?? sessionBehavior.real_interruption_guard ?? false,
       },
       vad: {
         vadProvider: assistant.vad?.name || getFallback(null, 'vad.name'),
@@ -859,7 +860,7 @@ export const buildFormValuesFromAgent = (assistant: any) => {
       },
       session: {
         preemptiveGeneration: (sessionBehavior.preemptive_generation || getFallback(null, 'session_behavior.preemptive_generation')) as "disabled" | "enabled",
-        turn_detection: (sessionBehavior.turn_detection || getFallback(null, 'session_behavior.turn_detection')) as "multilingual" | "english" | "smollm2turndetector" | "llmturndetector" | "smollm360m" | "disabled",
+        turn_detection: (sessionBehavior.turn_detection || getFallback(null, 'session_behavior.turn_detection')) as "multilingual" | "english" | "smollm2turndetector" | "llmturndetector" | "smollm360m" | "disabled" | "v1-mini",
         unlikely_threshold: sessionBehavior.unlikely_threshold ?? getFallback(null, 'session_behavior.unlikely_threshold'),
         min_endpointing_delay: sessionBehavior.min_endpointing_delay ?? getFallback(null, 'session_behavior.min_endpointing_delay'),
         max_endpointing_delay: sessionBehavior.max_endpointing_delay ?? getFallback(null, 'session_behavior.max_endpointing_delay'),

--- a/src/hooks/useAgentConfig.ts
+++ b/src/hooks/useAgentConfig.ts
@@ -174,7 +174,7 @@ export interface AgentConfigResponse {
       }
       session_behavior?: {
         preemptive_generation: string
-        turn_detection: "multilingual" | "english" | "smollm2" | "llm" | "smollm360m" | "disabled"
+        turn_detection: "multilingual" | "english" | "disabled"
         unlikely_threshold?: number
         min_endpointing_delay?: number
         max_endpointing_delay?: number
@@ -860,7 +860,7 @@ export const buildFormValuesFromAgent = (assistant: any) => {
       },
       session: {
         preemptiveGeneration: (sessionBehavior.preemptive_generation || getFallback(null, 'session_behavior.preemptive_generation')) as "disabled" | "enabled",
-        turn_detection: (sessionBehavior.turn_detection || getFallback(null, 'session_behavior.turn_detection')) as "multilingual" | "english" | "smollm2turndetector" | "llmturndetector" | "smollm360m" | "disabled" | "v1-mini",
+        turn_detection: (sessionBehavior.turn_detection || getFallback(null, 'session_behavior.turn_detection')) as "multilingual" | "english" | "disabled" | "v1-mini",
         unlikely_threshold: sessionBehavior.unlikely_threshold ?? getFallback(null, 'session_behavior.unlikely_threshold'),
         min_endpointing_delay: sessionBehavior.min_endpointing_delay ?? getFallback(null, 'session_behavior.min_endpointing_delay'),
         max_endpointing_delay: sessionBehavior.max_endpointing_delay ?? getFallback(null, 'session_behavior.max_endpointing_delay'),

--- a/src/hooks/useMultiAssistantState.ts
+++ b/src/hooks/useMultiAssistantState.ts
@@ -695,6 +695,7 @@ export function useMultiAssistantState({
         },
         interruption_mode: formValues.advancedSettings?.session?.interruption_mode ?? null,
         adaptive_stt: formValues.advancedSettings?.session?.interruption_mode === 'adaptive',
+        real_interruption_guard: formValues.advancedSettings?.interruption?.realInterruptionGuard ?? false,
         ...(formValues.advancedSettings?.session?.interruption_mode === 'adaptive' && {
           adaptive_min_duration: formValues.advancedSettings.interruption?.adaptiveMinDuration ?? 0.8,
           adaptive_min_words: formValues.advancedSettings.interruption?.adaptiveMinWords ?? 0,
@@ -906,6 +907,7 @@ export function useMultiAssistantState({
         },
         interruption_mode: formValues.advancedSettings?.session?.interruption_mode ?? null,
         adaptive_stt: formValues.advancedSettings?.session?.interruption_mode === 'adaptive',
+        real_interruption_guard: formValues.advancedSettings?.interruption?.realInterruptionGuard ?? false,
         ...(formValues.advancedSettings?.session?.interruption_mode === 'adaptive' && {
           adaptive_min_duration: formValues.advancedSettings.interruption?.adaptiveMinDuration ?? 0.8,
           adaptive_min_words: formValues.advancedSettings.interruption?.adaptiveMinWords ?? 0,

--- a/src/utils/agentConfigSerializer.ts
+++ b/src/utils/agentConfigSerializer.ts
@@ -83,7 +83,7 @@ export interface SerializedAgentConfig {
       }
       session: {
         preemptiveGeneration: 'disabled' | 'enabled'
-        turn_detection: 'multilingual' | 'english' | 'smollm2turndetector' | 'llmturndetector' | 'smollm360m' | 'disabled'
+        turn_detection: 'multilingual' | 'english' | 'disabled'
         unlikely_threshold?: number
         min_endpointing_delay?: number
         max_endpointing_delay?: number


### PR DESCRIPTION
## Summary
- Adds a "Real Interruption Guard (Beta)" toggle to the Interruption Settings panel, backed by a new `real_interruption_guard` field, wired end-to-end through form state, save/deploy payload, and agent-config load.
- Nests the toggle inside the VAD-only section of Interruption Mode — it's hidden entirely when Adaptive mode is selected, since Real Interruption Guard and LiveKit's adaptive interruption detector are mutually exclusive on the backend.
- Replaces the old Turn Detection options (`SmolLM2 Turn Detector`, `LLM Turn Detector`, `SmolLM360M`) with a single `V1 Mini (Real Interruption Classifier)` option, recommended alongside the new guard.

## Changes
- `InterruptionSettings.tsx` — new `realInterruptionGuard` prop + toggle UI, placed inside the `!isAdaptive` block.
- `AgentAdvancedSettings/index.tsx` — prop threading, `turn_detection` type updated to include `v1-mini`.
- `SessionBehaviourSettings.tsx` — `v1-mini` added to the Turn Detection select, old SmolLM/LLM turn-detector options removed.
- `agentDefaults.ts` — `realInterruptionGuard: false` default.
- `useAgentConfig.ts` — loads `real_interruption_guard` from either the top-level assistant field or `session_behavior` (backend hoists it into the latter for storage); `turn_detection` type updated.
- `useMultiAssistantState.ts` — saves `real_interruption_guard` unconditionally (both multi-assistant save-path blocks), independent of `interruption_mode`.
- `save-and-deploy/route.ts` — includes `real_interruption_guard` in the deployed agent config payload.

## Notes for reviewers
- Defaults to `false` for all existing and new agents — no behavior change unless explicitly enabled.
- Removing the three old turn-detector options is a breaking change for any agent currently configured with one of them — worth confirming none are in active use before merge, or the select will show an unrecognized/blank value for those agents.
- Backend-side enforcement (refusing to run the guard alongside adaptive mode even if both got set) lives in `pype-voice-agent`, not here — this PR only prevents selecting both from the UI.