### PR TITLE
feat: add real-interruption classifier guard, opt-in per agent

### DIFF
--- a/src/app/api/agents/save-and-deploy/route.ts
+++ b/src/app/api/agents/save-and-deploy/route.ts
@@ -543,6 +543,7 @@ function transformFormDataToAgentConfig(formData: any) {
           },
           interruption_mode: formikValues.advancedSettings.session.interruption_mode ?? null,
           adaptive_stt: formikValues.advancedSettings.session.interruption_mode === 'adaptive',
+          real_interruption_guard: formikValues.advancedSettings.interruption.realInterruptionGuard ?? false,
           ...buildRouteAdaptiveInterruptionPayload(formikValues),
           first_message_mode: firstMessageModeConfig
         }

--- a/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/InterruptionSettings.tsx
+++ b/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/InterruptionSettings.tsx
@@ -117,23 +117,6 @@ function InterruptionSettings({
 
       {allowInterruptions && (
         <>
-          {/* Real Interruption Guard */}
-          <div className="flex items-center justify-between">
-            <div className="pr-4">
-              <Label className="text-xs font-medium text-gray-700 dark:text-gray-300">
-                Real Interruption Guard (Beta)
-              </Label>
-              <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-                Filters out backchannels/false interruptions before cancelling agent speech. Turn Detection recommended "V1 Mini".
-              </div>
-            </div>
-            <Switch
-              checked={realInterruptionGuard}
-              onCheckedChange={(checked) => onFieldChange('advancedSettings.interruption.realInterruptionGuard', checked)}
-              className="scale-75"
-            />
-          </div>
-
           {/* Interruption Mode — segmented control */}
           <div className="space-y-2">
             <Label className="text-xs font-medium text-gray-700 dark:text-gray-300">
@@ -214,6 +197,23 @@ function InterruptionSettings({
                   value={minInterruptionWords}
                   onChange={(e) => onFieldChange('advancedSettings.interruption.minInterruptionWords', parseInt(e.target.value) || 0)}
                   className="h-7 text-xs"
+                />
+              </div>
+
+              {/* Real Interruption Guard — VAD mode only, conflicts with adaptive's own ML detector */}
+              <div className="flex items-center justify-between">
+                <div className="pr-4">
+                  <Label className="text-xs font-medium text-gray-700 dark:text-gray-300">
+                    Real Interruption Guard (Beta)
+                  </Label>
+                  <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                    Filters out backchannels/false interruptions before cancelling agent speech. Turn Detection recommended "V1 Mini".
+                  </div>
+                </div>
+                <Switch
+                  checked={realInterruptionGuard}
+                  onCheckedChange={(checked) => onFieldChange('advancedSettings.interruption.realInterruptionGuard', checked)}
+                  className="scale-75"
                 />
               </div>
             </>

--- a/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/InterruptionSettings.tsx
+++ b/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/InterruptionSettings.tsx
@@ -32,6 +32,7 @@ interface InterruptionSettingsProps {
   adaptiveFalseInterruptionTimeout?: number
   adaptiveBackchannelBoundaryStart?: number
   adaptiveBackchannelBoundaryEnd?: number
+  realInterruptionGuard?: boolean
   onFieldChange: (field: string, value: any) => void
 }
 
@@ -50,6 +51,7 @@ function InterruptionSettings({
   adaptiveFalseInterruptionTimeout = 2.0,
   adaptiveBackchannelBoundaryStart = 1.0,
   adaptiveBackchannelBoundaryEnd = 3.5,
+  realInterruptionGuard = false,
   onFieldChange
 }: InterruptionSettingsProps) {
   const [newWord, setNewWord] = useState('')
@@ -115,6 +117,23 @@ function InterruptionSettings({
 
       {allowInterruptions && (
         <>
+          {/* Real Interruption Guard */}
+          <div className="flex items-center justify-between">
+            <div className="pr-4">
+              <Label className="text-xs font-medium text-gray-700 dark:text-gray-300">
+                Real Interruption Guard (Beta)
+              </Label>
+              <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                Filters out backchannels/false interruptions before cancelling agent speech. Turn Detection recommended "V1 Mini".
+              </div>
+            </div>
+            <Switch
+              checked={realInterruptionGuard}
+              onCheckedChange={(checked) => onFieldChange('advancedSettings.interruption.realInterruptionGuard', checked)}
+              className="scale-75"
+            />
+          </div>
+
           {/* Interruption Mode — segmented control */}
           <div className="space-y-2">
             <Label className="text-xs font-medium text-gray-700 dark:text-gray-300">

--- a/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/InterruptionSettings.tsx
+++ b/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/InterruptionSettings.tsx
@@ -53,7 +53,7 @@ function InterruptionSettings({
   adaptiveBackchannelBoundaryEnd = 3.5,
   realInterruptionGuard = false,
   onFieldChange
-}: InterruptionSettingsProps) {
+}: Readonly<InterruptionSettingsProps>) {
   const [newWord, setNewWord] = useState('')
 
   const isAdaptive = interruption_mode === 'adaptive'

--- a/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/SessionBehaviourSettings.tsx
+++ b/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/SessionBehaviourSettings.tsx
@@ -7,7 +7,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 
 interface SessionBehaviourSettingsProps {
   preemptiveGeneration: 'enabled' | 'disabled'
-  turn_detection: 'multilingual' | 'english' | 'smollm2turndetector' | 'llmturndetector' | 'smollm360m' | 'disabled'
+  turn_detection: 'multilingual' | 'english' | 'smollm2turndetector' | 'llmturndetector' | 'smollm360m' | 'disabled' | 'v1-mini'
   unlikely_threshold?: number
   min_endpointing_delay?: number
   max_endpointing_delay?: number
@@ -205,6 +205,7 @@ export default function SessionBehaviourSettings({
               <SelectItem value="smollm2turndetector" className="text-xs">SmolLM2 Turn Detector</SelectItem>
               <SelectItem value="llmturndetector" className="text-xs">LLM Turn Detector</SelectItem>
               <SelectItem value="smollm360m" className="text-xs">SmolLM360M</SelectItem>
+              <SelectItem value="v1-mini" className="text-xs">V1 Mini (Real Interruption Classifier)</SelectItem>
               <SelectItem value="disabled" className="text-xs">Disabled</SelectItem>
             </SelectContent>
           </Select>

--- a/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/SessionBehaviourSettings.tsx
+++ b/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/SessionBehaviourSettings.tsx
@@ -7,7 +7,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 
 interface SessionBehaviourSettingsProps {
   preemptiveGeneration: 'enabled' | 'disabled'
-  turn_detection: 'multilingual' | 'english' | 'smollm2turndetector' | 'llmturndetector' | 'smollm360m' | 'disabled' | 'v1-mini'
+  turn_detection: 'multilingual' | 'english' | 'disabled' | 'v1-mini'
   unlikely_threshold?: number
   min_endpointing_delay?: number
   max_endpointing_delay?: number
@@ -202,9 +202,6 @@ export default function SessionBehaviourSettings({
             <SelectContent>
               <SelectItem value="multilingual" className="text-xs">Multilingual</SelectItem>
               <SelectItem value="english" className="text-xs">English</SelectItem>
-              <SelectItem value="smollm2turndetector" className="text-xs">SmolLM2 Turn Detector</SelectItem>
-              <SelectItem value="llmturndetector" className="text-xs">LLM Turn Detector</SelectItem>
-              <SelectItem value="smollm360m" className="text-xs">SmolLM360M</SelectItem>
               <SelectItem value="v1-mini" className="text-xs">V1 Mini (Real Interruption Classifier)</SelectItem>
               <SelectItem value="disabled" className="text-xs">Disabled</SelectItem>
             </SelectContent>

--- a/src/components/agents/AgentConfig/AgentAdvancedSettings/index.tsx
+++ b/src/components/agents/AgentConfig/AgentAdvancedSettings/index.tsx
@@ -36,6 +36,7 @@ interface AgentAdvancedSettingsProps {
         adaptiveFalseInterruptionTimeout?: number
         adaptiveBackchannelBoundaryStart?: number
         adaptiveBackchannelBoundaryEnd?: number
+        realInterruptionGuard?: boolean
       }
       vad: {
         vadProvider: string
@@ -49,7 +50,7 @@ interface AgentAdvancedSettingsProps {
       }
       session: {
         preemptiveGeneration: 'enabled' | 'disabled'
-        turn_detection: 'multilingual' | 'english' | 'smollm2turndetector' | 'llmturndetector' | 'smollm360m' | 'disabled'
+        turn_detection: 'multilingual' | 'english' | 'smollm2turndetector' | 'llmturndetector' | 'smollm360m' | 'disabled' | 'v1-mini'
         unlikely_threshold?: number
         min_endpointing_delay?: number
         max_endpointing_delay?: number
@@ -198,6 +199,7 @@ function AgentAdvancedSettings({ advancedSettings, onFieldChange, onWebhookDataL
               adaptiveFalseInterruptionTimeout={advancedSettings.interruption.adaptiveFalseInterruptionTimeout ?? 2.0}
               adaptiveBackchannelBoundaryStart={advancedSettings.interruption.adaptiveBackchannelBoundaryStart ?? 1.0}
               adaptiveBackchannelBoundaryEnd={advancedSettings.interruption.adaptiveBackchannelBoundaryEnd ?? 3.5}
+              realInterruptionGuard={advancedSettings.interruption.realInterruptionGuard ?? false}
               onFieldChange={onFieldChange}
             />
           </CollapsibleContent>

--- a/src/components/agents/AgentConfig/AgentAdvancedSettings/index.tsx
+++ b/src/components/agents/AgentConfig/AgentAdvancedSettings/index.tsx
@@ -50,7 +50,7 @@ interface AgentAdvancedSettingsProps {
       }
       session: {
         preemptiveGeneration: 'enabled' | 'disabled'
-        turn_detection: 'multilingual' | 'english' | 'smollm2turndetector' | 'llmturndetector' | 'smollm360m' | 'disabled' | 'v1-mini'
+        turn_detection: 'multilingual' | 'english' | 'disabled' | 'v1-mini'
         unlikely_threshold?: number
         min_endpointing_delay?: number
         max_endpointing_delay?: number

--- a/src/config/agentDefaults.ts
+++ b/src/config/agentDefaults.ts
@@ -227,6 +227,7 @@ export const AGENT_DEFAULT_CONFIG = {
         adaptiveFalseInterruptionTimeout: 2.0,
         adaptiveBackchannelBoundaryStart: 1.0,
         adaptiveBackchannelBoundaryEnd: 3.5,
+        realInterruptionGuard: false,
       },
       vad: {
         vadProvider: AGENT_DEFAULT_CONFIG.vad.name,

--- a/src/config/agentDefaults.ts
+++ b/src/config/agentDefaults.ts
@@ -241,7 +241,7 @@ export const AGENT_DEFAULT_CONFIG = {
       },
       session: {
         preemptiveGeneration: AGENT_DEFAULT_CONFIG.session_behavior.preemptive_generation as "disabled" | "enabled",
-        turn_detection: AGENT_DEFAULT_CONFIG.session_behavior.turn_detection as "multilingual" | "english" | "smollm2turndetector" | "llmturndetector" | "smollm360m" | "disabled",
+        turn_detection: AGENT_DEFAULT_CONFIG.session_behavior.turn_detection as "multilingual" | "english" | "disabled",
         unlikely_threshold: AGENT_DEFAULT_CONFIG.session_behavior.unlikely_threshold,
         min_endpointing_delay: AGENT_DEFAULT_CONFIG.session_behavior.min_endpointing_delay,
         max_endpointing_delay: AGENT_DEFAULT_CONFIG.session_behavior.max_endpointing_delay,

--- a/src/hooks/useAgentConfig.ts
+++ b/src/hooks/useAgentConfig.ts
@@ -840,6 +840,7 @@ export const buildFormValuesFromAgent = (assistant: any) => {
         adaptiveFalseInterruptionTimeout: assistant.adaptive_false_interruption_timeout ?? 2.0,
         adaptiveBackchannelBoundaryStart: assistant.adaptive_backchannel_boundary_start ?? 1.0,
         adaptiveBackchannelBoundaryEnd: assistant.adaptive_backchannel_boundary_end ?? 3.5,
+        realInterruptionGuard: assistant.real_interruption_guard ?? sessionBehavior.real_interruption_guard ?? false,
       },
       vad: {
         vadProvider: assistant.vad?.name || getFallback(null, 'vad.name'),
@@ -859,7 +860,7 @@ export const buildFormValuesFromAgent = (assistant: any) => {
       },
       session: {
         preemptiveGeneration: (sessionBehavior.preemptive_generation || getFallback(null, 'session_behavior.preemptive_generation')) as "disabled" | "enabled",
-        turn_detection: (sessionBehavior.turn_detection || getFallback(null, 'session_behavior.turn_detection')) as "multilingual" | "english" | "smollm2turndetector" | "llmturndetector" | "smollm360m" | "disabled",
+        turn_detection: (sessionBehavior.turn_detection || getFallback(null, 'session_behavior.turn_detection')) as "multilingual" | "english" | "smollm2turndetector" | "llmturndetector" | "smollm360m" | "disabled" | "v1-mini",
         unlikely_threshold: sessionBehavior.unlikely_threshold ?? getFallback(null, 'session_behavior.unlikely_threshold'),
         min_endpointing_delay: sessionBehavior.min_endpointing_delay ?? getFallback(null, 'session_behavior.min_endpointing_delay'),
         max_endpointing_delay: sessionBehavior.max_endpointing_delay ?? getFallback(null, 'session_behavior.max_endpointing_delay'),

--- a/src/hooks/useAgentConfig.ts
+++ b/src/hooks/useAgentConfig.ts
@@ -174,7 +174,7 @@ export interface AgentConfigResponse {
       }
       session_behavior?: {
         preemptive_generation: string
-        turn_detection: "multilingual" | "english" | "smollm2" | "llm" | "smollm360m" | "disabled"
+        turn_detection: "multilingual" | "english" | "disabled"
         unlikely_threshold?: number
         min_endpointing_delay?: number
         max_endpointing_delay?: number
@@ -860,7 +860,7 @@ export const buildFormValuesFromAgent = (assistant: any) => {
       },
       session: {
         preemptiveGeneration: (sessionBehavior.preemptive_generation || getFallback(null, 'session_behavior.preemptive_generation')) as "disabled" | "enabled",
-        turn_detection: (sessionBehavior.turn_detection || getFallback(null, 'session_behavior.turn_detection')) as "multilingual" | "english" | "smollm2turndetector" | "llmturndetector" | "smollm360m" | "disabled" | "v1-mini",
+        turn_detection: (sessionBehavior.turn_detection || getFallback(null, 'session_behavior.turn_detection')) as "multilingual" | "english" | "disabled" | "v1-mini",
         unlikely_threshold: sessionBehavior.unlikely_threshold ?? getFallback(null, 'session_behavior.unlikely_threshold'),
         min_endpointing_delay: sessionBehavior.min_endpointing_delay ?? getFallback(null, 'session_behavior.min_endpointing_delay'),
         max_endpointing_delay: sessionBehavior.max_endpointing_delay ?? getFallback(null, 'session_behavior.max_endpointing_delay'),

--- a/src/hooks/useMultiAssistantState.ts
+++ b/src/hooks/useMultiAssistantState.ts
@@ -695,6 +695,7 @@ export function useMultiAssistantState({
         },
         interruption_mode: formValues.advancedSettings?.session?.interruption_mode ?? null,
         adaptive_stt: formValues.advancedSettings?.session?.interruption_mode === 'adaptive',
+        real_interruption_guard: formValues.advancedSettings?.interruption?.realInterruptionGuard ?? false,
         ...(formValues.advancedSettings?.session?.interruption_mode === 'adaptive' && {
           adaptive_min_duration: formValues.advancedSettings.interruption?.adaptiveMinDuration ?? 0.8,
           adaptive_min_words: formValues.advancedSettings.interruption?.adaptiveMinWords ?? 0,
@@ -906,6 +907,7 @@ export function useMultiAssistantState({
         },
         interruption_mode: formValues.advancedSettings?.session?.interruption_mode ?? null,
         adaptive_stt: formValues.advancedSettings?.session?.interruption_mode === 'adaptive',
+        real_interruption_guard: formValues.advancedSettings?.interruption?.realInterruptionGuard ?? false,
         ...(formValues.advancedSettings?.session?.interruption_mode === 'adaptive' && {
           adaptive_min_duration: formValues.advancedSettings.interruption?.adaptiveMinDuration ?? 0.8,
           adaptive_min_words: formValues.advancedSettings.interruption?.adaptiveMinWords ?? 0,

--- a/src/hooks/useMultiAssistantState.ts
+++ b/src/hooks/useMultiAssistantState.ts
@@ -157,6 +157,10 @@ function buildFallbackTtsPayload(formValues: any) {
   }
 }
 
+function getRealInterruptionGuard(formValues: any): boolean {
+  return formValues.advancedSettings?.interruption?.realInterruptionGuard ?? false
+}
+
 function buildSingleAssistantSttPayload(formValues: any, currentSttConfig: any): any {
   const rawConfig = formValues.sttConfig || currentSttConfig?.config || {}
   const { language: _l, mode: _m, model: _mo, tier: _t, version: _v,
@@ -695,7 +699,7 @@ export function useMultiAssistantState({
         },
         interruption_mode: formValues.advancedSettings?.session?.interruption_mode ?? null,
         adaptive_stt: formValues.advancedSettings?.session?.interruption_mode === 'adaptive',
-        real_interruption_guard: formValues.advancedSettings?.interruption?.realInterruptionGuard ?? false,
+        real_interruption_guard: getRealInterruptionGuard(formValues),
         ...(formValues.advancedSettings?.session?.interruption_mode === 'adaptive' && {
           adaptive_min_duration: formValues.advancedSettings.interruption?.adaptiveMinDuration ?? 0.8,
           adaptive_min_words: formValues.advancedSettings.interruption?.adaptiveMinWords ?? 0,
@@ -907,7 +911,7 @@ export function useMultiAssistantState({
         },
         interruption_mode: formValues.advancedSettings?.session?.interruption_mode ?? null,
         adaptive_stt: formValues.advancedSettings?.session?.interruption_mode === 'adaptive',
-        real_interruption_guard: formValues.advancedSettings?.interruption?.realInterruptionGuard ?? false,
+        real_interruption_guard: getRealInterruptionGuard(formValues),
         ...(formValues.advancedSettings?.session?.interruption_mode === 'adaptive' && {
           adaptive_min_duration: formValues.advancedSettings.interruption?.adaptiveMinDuration ?? 0.8,
           adaptive_min_words: formValues.advancedSettings.interruption?.adaptiveMinWords ?? 0,

--- a/src/hooks/useMultiAssistantState.ts
+++ b/src/hooks/useMultiAssistantState.ts
@@ -166,6 +166,193 @@ function getInterruptionModeFields(formValues: any): { interruption_mode: string
   }
 }
 
+function buildAssistantPayload(formValues: any, opts: {
+  name: string
+  stt: any
+  llm: any
+  tts: any
+  tools: any
+  // Single-assistant and multi-assistant save paths disagree on whether
+  // background_audio's single/dual fields fall back to a default when the
+  // form value is empty (single-assistant does, multi-assistant doesn't) --
+  // a pre-existing behavioral difference, preserved here rather than
+  // silently unified.
+  useBackgroundAudioFallbacks: boolean
+}): any {
+  const variablesObject = Array.isArray(formValues.variables)
+    ? formValues.variables.reduce((acc: any, v: any) => {
+        acc[v.name] = v.value
+        return acc
+      }, {})
+    : formValues.variables || {}
+
+  const firstMessageModeConfig = typeof formValues.firstMessageMode === 'object'
+    ? {
+        mode: formValues.firstMessageMode.mode,
+        first_message: formValues.firstMessageMode.first_message || '',
+        allow_interruptions: formValues.firstMessageMode.allow_interruptions ?? getFallback(null, 'first_message_mode.allow_interruptions')
+      }
+    : {
+        mode: formValues.firstMessageMode || getFallback(null, 'first_message_mode.mode'),
+        first_message: formValues.customFirstMessage || getFallback(null, 'first_message_mode.first_message'),
+        allow_interruptions: getFallback(null, 'first_message_mode.allow_interruptions')
+      }
+
+  const singleBackgroundAudio = opts.useBackgroundAudioFallbacks
+    ? {
+        type: formValues.advancedSettings?.backgroundAudio?.singleType || 'keyboard',
+        volume: formValues.advancedSettings?.backgroundAudio?.singleVolume ?? 0.5,
+        timing: formValues.advancedSettings?.backgroundAudio?.singleTiming || 'thinking'
+      }
+    : {
+        type: formValues.advancedSettings?.backgroundAudio?.singleType,
+        volume: formValues.advancedSettings?.backgroundAudio?.singleVolume,
+        timing: formValues.advancedSettings?.backgroundAudio?.singleTiming
+      }
+
+  const dualBackgroundAudio = opts.useBackgroundAudioFallbacks
+    ? {
+        ambient: {
+          type: formValues.advancedSettings?.backgroundAudio?.ambientType || getFallback(null, 'background_audio.ambient.type'),
+          volume: formValues.advancedSettings?.backgroundAudio?.ambientVolume ?? getFallback(null, 'background_audio.ambient.volume')
+        },
+        thinking: {
+          type: formValues.advancedSettings?.backgroundAudio?.thinkingType || getFallback(null, 'background_audio.thinking.type'),
+          volume: formValues.advancedSettings?.backgroundAudio?.thinkingVolume ?? getFallback(null, 'background_audio.thinking.volume')
+        }
+      }
+    : {
+        ambient: {
+          type: formValues.advancedSettings?.backgroundAudio?.ambientType,
+          volume: formValues.advancedSettings?.backgroundAudio?.ambientVolume
+        },
+        thinking: {
+          type: formValues.advancedSettings?.backgroundAudio?.thinkingType,
+          volume: formValues.advancedSettings?.backgroundAudio?.thinkingVolume
+        }
+      }
+
+  return {
+    name: opts.name,
+    prompt: formValues.prompt || '',
+    variables: variablesObject,
+    stt: opts.stt,
+    llm: opts.llm,
+    tts: opts.tts,
+    vad: {
+      name: formValues.advancedSettings?.vad?.vadProvider || getFallback(null, 'vad.name'),
+      ...(formValues.advancedSettings?.vad?.minSilenceDuration !== undefined && {
+        min_silence_duration: formValues.advancedSettings.vad.minSilenceDuration
+      }),
+      ...(formValues.advancedSettings?.vad?.minSpeechDuration !== undefined && {
+        min_speech_duration: formValues.advancedSettings.vad.minSpeechDuration
+      }),
+      ...(formValues.advancedSettings?.vad?.prefixPaddingDuration !== undefined && {
+        prefix_padding_duration: formValues.advancedSettings.vad.prefixPaddingDuration
+      }),
+      ...(formValues.advancedSettings?.vad?.maxBufferedSpeech !== undefined && {
+        max_buffered_speech: formValues.advancedSettings.vad.maxBufferedSpeech
+      }),
+      ...(formValues.advancedSettings?.vad?.activationThreshold !== undefined && {
+        activation_threshold: formValues.advancedSettings.vad.activationThreshold
+      }),
+      ...(formValues.advancedSettings?.vad?.sampleRate !== undefined && {
+        sample_rate: formValues.advancedSettings.vad.sampleRate
+      }),
+      ...(formValues.advancedSettings?.vad?.forceCpu !== undefined && {
+        force_cpu: formValues.advancedSettings.vad.forceCpu
+      })
+    },
+    tools: opts.tools,
+    filler_words: {
+      enabled: (formValues.advancedSettings?.fillers?.enableFillerWords ?? false) && [
+        ...(formValues.advancedSettings?.fillers?.generalFillers ?? []),
+        ...(formValues.advancedSettings?.fillers?.questionFillers ?? []),
+        ...(formValues.advancedSettings?.fillers?.ambiguousFillers ?? []),
+      ].some((w: string) => w !== ''),
+      language: formValues.advancedSettings?.fillers?.language ?? 'auto',
+      question_keywords: formValues.advancedSettings?.fillers?.questionKeywords?.filter((f: string) => f !== '') ?? [],
+      question_fillers: formValues.advancedSettings?.fillers?.questionFillers?.filter((f: string) => f !== '') ?? [],
+      ambiguous_keywords: formValues.advancedSettings?.fillers?.ambiguousKeywords?.filter((f: string) => f !== '') ?? [],
+      ambiguous_fillers: formValues.advancedSettings?.fillers?.ambiguousFillers?.filter((f: string) => f !== '') ?? [],
+      general_fillers: formValues.advancedSettings?.fillers?.generalFillers?.filter((f: string) => f !== '') ?? [],
+      typing_probability: formValues.advancedSettings?.backgroundAudio?.thinkingProbability ?? 0.10,
+      filler_cooldown_sec: formValues.advancedSettings?.fillers?.fillerCooldownSec ?? 4.0,
+      latency_threshold: formValues.advancedSettings?.fillers?.latencyThreshold ?? 1.2,
+      conversation_fillers: formValues.advancedSettings?.fillers?.conversationFillers?.filter((f: string) => f !== '') ?? [],
+      conversation_keywords: formValues.advancedSettings?.fillers?.conversationKeywords?.filter((f: string) => f !== '') ?? [],
+    },
+    bug_reports: {
+      enable: formValues.advancedSettings?.bugs?.enableBugReport ?? getFallback(null, 'bug_reports.enable'),
+      bug_start_command: formValues.advancedSettings?.bugs?.bugStartCommands || getFallback(null, 'bug_reports.bug_start_command'),
+      bug_end_command: formValues.advancedSettings?.bugs?.bugEndCommands || getFallback(null, 'bug_reports.bug_end_command'),
+      response: formValues.advancedSettings?.bugs?.initialResponse || getFallback(null, 'bug_reports.response'),
+      collection_prompt: formValues.advancedSettings?.bugs?.collectionPrompt || getFallback(null, 'bug_reports.collection_prompt')
+    },
+    context_memory: {
+      enabled: formValues.advancedSettings?.contextMemory?.enabled ?? false
+    },
+    interruptions: {
+      allow_interruptions: formValues.advancedSettings?.interruption?.allowInterruptions ?? getFallback(null, 'interruptions.allow_interruptions'),
+      min_interruption_duration: formValues.advancedSettings?.interruption?.minInterruptionDuration ?? getFallback(null, 'interruptions.min_interruption_duration'),
+      min_interruption_words: formValues.advancedSettings?.interruption?.minInterruptionWords ?? getFallback(null, 'interruptions.min_interruption_words'),
+      drop_filler_words: formValues.advancedSettings?.interruption?.dropFillerWords ?? false,
+      filler_drop_list: formValues.advancedSettings?.interruption?.fillerDropList ?? [],
+    },
+    ...getInterruptionModeFields(formValues),
+    ...(formValues.advancedSettings?.session?.interruption_mode === 'adaptive' && {
+      adaptive_min_duration: formValues.advancedSettings.interruption?.adaptiveMinDuration ?? 0.8,
+      adaptive_min_words: formValues.advancedSettings.interruption?.adaptiveMinWords ?? 0,
+      adaptive_discard_audio_if_uninterruptible: formValues.advancedSettings.interruption?.adaptiveDiscardAudioIfUninterruptible ?? true,
+      adaptive_resume_false_interruption: formValues.advancedSettings.interruption?.adaptiveResumeFalseInterruption ?? true,
+      adaptive_false_interruption_timeout: formValues.advancedSettings.interruption?.adaptiveFalseInterruptionTimeout ?? 0.5,
+      adaptive_backchannel_boundary_start: formValues.advancedSettings.interruption?.adaptiveBackchannelBoundaryStart ?? 0.1,
+      adaptive_backchannel_boundary_end: formValues.advancedSettings.interruption?.adaptiveBackchannelBoundaryEnd ?? 2,
+    }),
+    first_message_mode: firstMessageModeConfig,
+    first_message: firstMessageModeConfig.first_message,
+    turn_detection: formValues.advancedSettings?.session?.turn_detection || getFallback(null, 'session_behavior.turn_detection'),
+    session_behavior: {
+      preemptive_generation: formValues.advancedSettings?.session?.preemptiveGeneration || getFallback(null, 'session_behavior.preemptive_generation'),
+      turn_detection: formValues.advancedSettings?.session?.turn_detection || getFallback(null, 'session_behavior.turn_detection'),
+      unlikely_threshold: formValues.advancedSettings?.session?.unlikely_threshold ?? getFallback(null, 'session_behavior.unlikely_threshold'),
+      min_endpointing_delay: formValues.advancedSettings?.session?.min_endpointing_delay ?? getFallback(null, 'session_behavior.min_endpointing_delay'),
+      max_endpointing_delay: formValues.advancedSettings?.session?.max_endpointing_delay ?? getFallback(null, 'session_behavior.max_endpointing_delay'),
+      ...(formValues.advancedSettings?.session?.endpointing_mode && {
+        endpointing_mode: formValues.advancedSettings.session.endpointing_mode
+      }),
+      // interruption_mode is intentionally omitted here — it's sent at the top level
+      // above and the backend hoists it into session_behavior on save.
+      ...(formValues.advancedSettings?.session?.user_away_timeout !== undefined && {
+        user_away_timeout: formValues.advancedSettings.session.user_away_timeout
+      }),
+      ...(formValues.advancedSettings?.session?.user_away_timeout_message !== undefined && formValues.advancedSettings.session.user_away_timeout_message !== null && {
+        user_away_timeout_message: formValues.advancedSettings.session.user_away_timeout_message
+      }),
+      ...(formValues.advancedSettings?.session?.user_away_timeout_max_count !== undefined && {
+        user_away_timeout_max_count: formValues.advancedSettings.session.user_away_timeout_max_count
+      }),
+      ...(formValues.advancedSettings?.session?.user_away_timeout_end_message !== undefined && formValues.advancedSettings.session.user_away_timeout_end_message !== null && formValues.advancedSettings.session.user_away_timeout_end_message !== '' && {
+        user_away_timeout_end_message: formValues.advancedSettings.session.user_away_timeout_end_message
+      })
+    },
+    background_audio: {
+      enabled: formValues.advancedSettings?.backgroundAudio?.mode !== 'disabled',
+      thinking_probability: formValues.advancedSettings?.backgroundAudio?.thinkingProbability ?? 1.0,
+      tool_call_typing_config: {
+        enabled: formValues.advancedSettings?.backgroundAudio?.toolCallTyping ?? false,
+        volume: formValues.advancedSettings?.backgroundAudio?.toolCallVolume ?? 0.8
+      },
+      ...(formValues.advancedSettings?.backgroundAudio?.mode === 'single' && singleBackgroundAudio),
+      ...(formValues.advancedSettings?.backgroundAudio?.mode === 'dual' && dualBackgroundAudio)
+    },
+    ...(formValues.dynamic_tts && formValues.dynamic_tts.length > 0 && {
+      dynamic_tts: formValues.dynamic_tts
+    }),
+    fallback_global_enabled: !!formValues.fallbackGlobalEnabled,
+  }
+}
+
 function buildSingleAssistantSttPayload(formValues: any, currentSttConfig: any): any {
   const rawConfig = formValues.sttConfig || currentSttConfig?.config || {}
   const { language: _l, mode: _m, model: _mo, tier: _t, version: _v,
@@ -611,162 +798,19 @@ export function useMultiAssistantState({
   const buildSavePayload = useCallback(() => {
     if (currentFormik && assistantNames.length <= 1) {
       const formValues = currentFormik.values
-      
-      const variablesObject = Array.isArray(formValues.variables)
-        ? formValues.variables.reduce((acc: any, v: any) => {
-            acc[v.name] = v.value
-            return acc
-          }, {})
-        : formValues.variables || {}
 
-      const firstMessageModeConfig = typeof formValues.firstMessageMode === 'object'
-        ? {
-            mode: formValues.firstMessageMode.mode,
-            first_message: formValues.firstMessageMode.first_message || '',
-            allow_interruptions: formValues.firstMessageMode.allow_interruptions ?? getFallback(null, 'first_message_mode.allow_interruptions')
-          }
-        : {
-            mode: formValues.firstMessageMode || getFallback(null, 'first_message_mode.mode'),
-            first_message: formValues.customFirstMessage || getFallback(null, 'first_message_mode.first_message'),
-            allow_interruptions: getFallback(null, 'first_message_mode.allow_interruptions')
-          }
-
-      const assistant = {
+      const assistant = buildAssistantPayload(formValues, {
         name: agentName,
-        prompt: formValues.prompt || '',
-        variables: variablesObject,
         stt: buildSingleAssistantSttPayload(formValues, currentSttConfig),
         llm: buildSingleAssistantLlmPayload(formValues, currentAzureConfig, fallbackAzureConfig),
         tts: buildSingleAssistantTtsPayload(formValues, currentTtsConfig),
-        vad: {
-          name: formValues.advancedSettings?.vad?.vadProvider || getFallback(null, 'vad.name'),
-          ...(formValues.advancedSettings?.vad?.minSilenceDuration !== undefined && {
-            min_silence_duration: formValues.advancedSettings.vad.minSilenceDuration
-          }),
-          ...(formValues.advancedSettings?.vad?.minSpeechDuration !== undefined && {
-            min_speech_duration: formValues.advancedSettings.vad.minSpeechDuration
-          }),
-          ...(formValues.advancedSettings?.vad?.prefixPaddingDuration !== undefined && {
-            prefix_padding_duration: formValues.advancedSettings.vad.prefixPaddingDuration
-          }),
-          ...(formValues.advancedSettings?.vad?.maxBufferedSpeech !== undefined && {
-            max_buffered_speech: formValues.advancedSettings.vad.maxBufferedSpeech
-          }),
-          ...(formValues.advancedSettings?.vad?.activationThreshold !== undefined && {
-            activation_threshold: formValues.advancedSettings.vad.activationThreshold
-          }),
-          ...(formValues.advancedSettings?.vad?.sampleRate !== undefined && {
-            sample_rate: formValues.advancedSettings.vad.sampleRate
-          }),
-          ...(formValues.advancedSettings?.vad?.forceCpu !== undefined && {
-            force_cpu: formValues.advancedSettings.vad.forceCpu
-          })
-        },
         tools: (() => {
           const mappedTools = formValues.advancedSettings?.tools?.tools?.map(serializeAssistantToolFull) || getFallback(null, 'tools') || []
           const filteredTools = mergeToolsWithKbAndLanguageSwitch(formValues, mappedTools)
           return filteredTools.length > 0 ? filteredTools : getFallback(null, 'tools')
         })(),
-        filler_words: {
-          enabled: (formValues.advancedSettings?.fillers?.enableFillerWords ?? false) && [
-            ...(formValues.advancedSettings?.fillers?.generalFillers ?? []),
-            ...(formValues.advancedSettings?.fillers?.questionFillers ?? []),
-            ...(formValues.advancedSettings?.fillers?.ambiguousFillers ?? []),
-          ].some((w: string) => w !== ''),
-          language: formValues.advancedSettings?.fillers?.language ?? 'auto',
-          question_keywords: formValues.advancedSettings?.fillers?.questionKeywords?.filter((f: string) => f !== '') ?? [],
-          question_fillers: formValues.advancedSettings?.fillers?.questionFillers?.filter((f: string) => f !== '') ?? [],
-          ambiguous_keywords: formValues.advancedSettings?.fillers?.ambiguousKeywords?.filter((f: string) => f !== '') ?? [],
-          ambiguous_fillers: formValues.advancedSettings?.fillers?.ambiguousFillers?.filter((f: string) => f !== '') ?? [],
-          general_fillers: formValues.advancedSettings?.fillers?.generalFillers?.filter((f: string) => f !== '') ?? [],
-          typing_probability: formValues.advancedSettings?.backgroundAudio?.thinkingProbability ?? 0.10,
-          filler_cooldown_sec: formValues.advancedSettings?.fillers?.fillerCooldownSec ?? 4.0,
-          latency_threshold: formValues.advancedSettings?.fillers?.latencyThreshold ?? 1.2,
-          conversation_fillers: formValues.advancedSettings?.fillers?.conversationFillers?.filter((f: string) => f !== '') ?? [],
-          conversation_keywords: formValues.advancedSettings?.fillers?.conversationKeywords?.filter((f: string) => f !== '') ?? [],
-        },
-        bug_reports: {
-          enable: formValues.advancedSettings?.bugs?.enableBugReport ?? getFallback(null, 'bug_reports.enable'),
-          bug_start_command: formValues.advancedSettings?.bugs?.bugStartCommands || getFallback(null, 'bug_reports.bug_start_command'),
-          bug_end_command: formValues.advancedSettings?.bugs?.bugEndCommands || getFallback(null, 'bug_reports.bug_end_command'),
-          response: formValues.advancedSettings?.bugs?.initialResponse || getFallback(null, 'bug_reports.response'),
-          collection_prompt: formValues.advancedSettings?.bugs?.collectionPrompt || getFallback(null, 'bug_reports.collection_prompt')
-        },
-        context_memory: {
-          enabled: formValues.advancedSettings?.contextMemory?.enabled ?? false
-        },
-        interruptions: {
-          allow_interruptions: formValues.advancedSettings?.interruption?.allowInterruptions ?? getFallback(null, 'interruptions.allow_interruptions'),
-          min_interruption_duration: formValues.advancedSettings?.interruption?.minInterruptionDuration ?? getFallback(null, 'interruptions.min_interruption_duration'),
-          min_interruption_words: formValues.advancedSettings?.interruption?.minInterruptionWords ?? getFallback(null, 'interruptions.min_interruption_words'),
-          drop_filler_words: formValues.advancedSettings?.interruption?.dropFillerWords ?? false,
-          filler_drop_list: formValues.advancedSettings?.interruption?.fillerDropList ?? [],
-        },
-        ...getInterruptionModeFields(formValues),
-        ...(formValues.advancedSettings?.session?.interruption_mode === 'adaptive' && {
-          adaptive_min_duration: formValues.advancedSettings.interruption?.adaptiveMinDuration ?? 0.8,
-          adaptive_min_words: formValues.advancedSettings.interruption?.adaptiveMinWords ?? 0,
-          adaptive_discard_audio_if_uninterruptible: formValues.advancedSettings.interruption?.adaptiveDiscardAudioIfUninterruptible ?? true,
-          adaptive_resume_false_interruption: formValues.advancedSettings.interruption?.adaptiveResumeFalseInterruption ?? true,
-          adaptive_false_interruption_timeout: formValues.advancedSettings.interruption?.adaptiveFalseInterruptionTimeout ?? 0.5,
-          adaptive_backchannel_boundary_start: formValues.advancedSettings.interruption?.adaptiveBackchannelBoundaryStart ?? 0.1,
-          adaptive_backchannel_boundary_end: formValues.advancedSettings.interruption?.adaptiveBackchannelBoundaryEnd ?? 2,
-        }),
-        first_message_mode: firstMessageModeConfig,
-        first_message: firstMessageModeConfig.first_message,
-        turn_detection: formValues.advancedSettings?.session?.turn_detection || getFallback(null, 'session_behavior.turn_detection'),
-        session_behavior: {
-          preemptive_generation: formValues.advancedSettings?.session?.preemptiveGeneration || getFallback(null, 'session_behavior.preemptive_generation'),
-          turn_detection: formValues.advancedSettings?.session?.turn_detection || getFallback(null, 'session_behavior.turn_detection'),
-          unlikely_threshold: formValues.advancedSettings?.session?.unlikely_threshold ?? getFallback(null, 'session_behavior.unlikely_threshold'),
-          min_endpointing_delay: formValues.advancedSettings?.session?.min_endpointing_delay ?? getFallback(null, 'session_behavior.min_endpointing_delay'),
-          max_endpointing_delay: formValues.advancedSettings?.session?.max_endpointing_delay ?? getFallback(null, 'session_behavior.max_endpointing_delay'),
-          ...(formValues.advancedSettings?.session?.endpointing_mode && {
-            endpointing_mode: formValues.advancedSettings.session.endpointing_mode
-          }),
-          // interruption_mode is intentionally omitted here — it's sent at the top level
-          // above and the backend hoists it into session_behavior on save.
-          ...(formValues.advancedSettings?.session?.user_away_timeout !== undefined && {
-            user_away_timeout: formValues.advancedSettings.session.user_away_timeout
-          }),
-          ...(formValues.advancedSettings?.session?.user_away_timeout_message !== undefined && formValues.advancedSettings.session.user_away_timeout_message !== null && {
-            user_away_timeout_message: formValues.advancedSettings.session.user_away_timeout_message
-          }),
-          ...(formValues.advancedSettings?.session?.user_away_timeout_max_count !== undefined && {
-            user_away_timeout_max_count: formValues.advancedSettings.session.user_away_timeout_max_count
-          }),
-          ...(formValues.advancedSettings?.session?.user_away_timeout_end_message !== undefined && formValues.advancedSettings.session.user_away_timeout_end_message !== null && formValues.advancedSettings.session.user_away_timeout_end_message !== '' && {
-            user_away_timeout_end_message: formValues.advancedSettings.session.user_away_timeout_end_message
-          })
-        },
-        background_audio: {
-          enabled: formValues.advancedSettings?.backgroundAudio?.mode !== 'disabled',
-          thinking_probability: formValues.advancedSettings?.backgroundAudio?.thinkingProbability ?? 1.0,
-          tool_call_typing_config: {
-            enabled: formValues.advancedSettings?.backgroundAudio?.toolCallTyping ?? false,
-            volume: formValues.advancedSettings?.backgroundAudio?.toolCallVolume ?? 0.8
-          },
-          ...(formValues.advancedSettings?.backgroundAudio?.mode === 'single' && {
-            type: formValues.advancedSettings.backgroundAudio.singleType || 'keyboard',
-            volume: formValues.advancedSettings.backgroundAudio.singleVolume ?? 0.5,
-            timing: formValues.advancedSettings.backgroundAudio.singleTiming || 'thinking'
-          }),
-          ...(formValues.advancedSettings?.backgroundAudio?.mode === 'dual' && {
-            ambient: {
-              type: formValues.advancedSettings.backgroundAudio.ambientType || getFallback(null, 'background_audio.ambient.type'),
-              volume: formValues.advancedSettings.backgroundAudio.ambientVolume ?? getFallback(null, 'background_audio.ambient.volume')
-            },
-            thinking: {
-              type: formValues.advancedSettings.backgroundAudio.thinkingType || getFallback(null, 'background_audio.thinking.type'),
-              volume: formValues.advancedSettings.backgroundAudio.thinkingVolume ?? getFallback(null, 'background_audio.thinking.volume')
-            }
-          })
-        },
-        ...(formValues.dynamic_tts && formValues.dynamic_tts.length > 0 && {
-          dynamic_tts: formValues.dynamic_tts
-        }),
-        fallback_global_enabled: !!formValues.fallbackGlobalEnabled,
-      }
+        useBackgroundAudioFallbacks: true,
+      })
 
       return buildAgentEnvelope(agentName, agentType, [assistant], agentId)
     }
@@ -775,30 +819,9 @@ export function useMultiAssistantState({
     const assistants = assistantNames.map(name => {
       const data = assistantsData.get(name) || getAssistantData(name)
       const formValues = data.formikRef?.values || {}
-      
-      const variablesObject = Array.isArray(formValues.variables)
-        ? formValues.variables.reduce((acc: any, v: any) => {
-            acc[v.name] = v.value
-            return acc
-          }, {})
-        : formValues.variables || {}
 
-      const firstMessageModeConfig = typeof formValues.firstMessageMode === 'object'
-        ? {
-            mode: formValues.firstMessageMode.mode,
-            first_message: formValues.firstMessageMode.first_message || '',
-            allow_interruptions: formValues.firstMessageMode.allow_interruptions ?? getFallback(null, 'first_message_mode.allow_interruptions')
-          }
-        : {
-            mode: formValues.firstMessageMode || getFallback(null, 'first_message_mode.mode'),
-            first_message: formValues.customFirstMessage || getFallback(null, 'first_message_mode.first_message'),
-            allow_interruptions: getFallback(null, 'first_message_mode.allow_interruptions')
-          }
-      
-      return {
-        name: name,
-        prompt: formValues.prompt || '',
-        variables: variablesObject,
+      return buildAssistantPayload(formValues, {
+        name,
         stt: {
           name: data.sttConfig?.name || formValues.sttProvider || getFallback(null, 'stt.name'),
           language: data.sttConfig?.language || formValues.sttConfig?.language || getFallback(null, 'stt.language'),
@@ -807,38 +830,7 @@ export function useMultiAssistantState({
             mode: data.sttConfig?.mode || formValues.sttConfig?.mode
           }),
         },
-        llm: {
-          name: formValues.selectedProvider || getFallback(null, 'llm.name'),
-          provider: formValues.selectedProvider === 'azure_openai' ? 'azure' : formValues.selectedProvider || getFallback(null, 'llm.provider'),
-          model: formValues.selectedModel || getFallback(null, 'llm.model'),
-          temperature: formValues.temperature ?? getFallback(null, 'llm.temperature'),
-          ...(formValues.selectedProvider === 'azure_openai' && currentAzureConfig && {
-            azure_deployment: currentAzureConfig.deploymentName || getFallback(null, 'llm.azure_deployment'),
-            azure_endpoint: currentAzureConfig.endpoint || getFallback(null, 'llm.azure_endpoint'),
-            api_version: currentAzureConfig.apiVersion || getFallback(null, 'llm.api_version'),
-            api_key_env: getFallback(null, 'llm.api_key_env')
-          }),
-          ...(formValues.selectedProvider === 'openai' && { api_key_env: 'OPENAI_API_KEY' }),
-          ...(formValues.selectedProvider === 'groq' && { api_key_env: 'GROQ_API_KEY' }),
-          ...(formValues.selectedProvider === 'cerebras' && { api_key_env: 'CEREBRAS_API_KEY' }),
-          ...(formValues.fallbackLlmProvider && {
-            fallback: {
-              name: formValues.fallbackLlmProvider,
-              provider: formValues.fallbackLlmProvider === 'azure_openai' ? 'azure' : formValues.fallbackLlmProvider,
-              model: formValues.fallbackLlmModel || getFallback(null, 'llm.model'),
-              temperature: formValues.fallbackLlmTemperature ?? getFallback(null, 'llm.temperature'),
-              ...(formValues.fallbackLlmProvider === 'azure_openai' && fallbackAzureConfig && {
-                azure_deployment: fallbackAzureConfig.deploymentName || getFallback(null, 'llm.azure_deployment'),
-                azure_endpoint: fallbackAzureConfig.endpoint || getFallback(null, 'llm.azure_endpoint'),
-                api_version: fallbackAzureConfig.apiVersion || getFallback(null, 'llm.api_version'),
-                api_key_env: getFallback(null, 'llm.api_key_env')
-              }),
-              ...(formValues.fallbackLlmProvider === 'openai' && { api_key_env: 'OPENAI_API_KEY' }),
-              ...(formValues.fallbackLlmProvider === 'groq' && { api_key_env: 'GROQ_API_KEY' }),
-              ...(formValues.fallbackLlmProvider === 'cerebras' && { api_key_env: 'CEREBRAS_API_KEY' }),
-            }
-          }),
-        },
+        llm: buildSingleAssistantLlmPayload(formValues, currentAzureConfig, fallbackAzureConfig),
         tts: {
           name: data.ttsConfig?.name || formValues.ttsProvider || getFallback(null, 'tts.name'),
           voice_id: data.ttsConfig?.voice_id || formValues.selectedVoice || getFallback(null, 'tts.voice_id'),
@@ -852,131 +844,9 @@ export function useMultiAssistantState({
             speed: data.ttsConfig?.voice_settings?.speed ?? formValues.ttsVoiceConfig?.speed ?? getFallback(null, 'tts.voice_settings.speed')
           }
         },
-        vad: {
-          name: formValues.advancedSettings?.vad?.vadProvider || getFallback(null, 'vad.name'),
-          ...(formValues.advancedSettings?.vad?.minSilenceDuration !== undefined && {
-            min_silence_duration: formValues.advancedSettings.vad.minSilenceDuration
-          }),
-          ...(formValues.advancedSettings?.vad?.minSpeechDuration !== undefined && {
-            min_speech_duration: formValues.advancedSettings.vad.minSpeechDuration
-          }),
-          ...(formValues.advancedSettings?.vad?.prefixPaddingDuration !== undefined && {
-            prefix_padding_duration: formValues.advancedSettings.vad.prefixPaddingDuration
-          }),
-          ...(formValues.advancedSettings?.vad?.maxBufferedSpeech !== undefined && {
-            max_buffered_speech: formValues.advancedSettings.vad.maxBufferedSpeech
-          }),
-          ...(formValues.advancedSettings?.vad?.activationThreshold !== undefined && {
-            activation_threshold: formValues.advancedSettings.vad.activationThreshold
-          }),
-          ...(formValues.advancedSettings?.vad?.sampleRate !== undefined && {
-            sample_rate: formValues.advancedSettings.vad.sampleRate
-          }),
-          ...(formValues.advancedSettings?.vad?.forceCpu !== undefined && {
-            force_cpu: formValues.advancedSettings.vad.forceCpu
-          })
-        },
         tools: formValues.advancedSettings?.tools?.tools?.map(serializeAssistantToolBasic) || getFallback(null, 'tools'),
-        filler_words: {
-          enabled: (formValues.advancedSettings?.fillers?.enableFillerWords ?? false) && [
-            ...(formValues.advancedSettings?.fillers?.generalFillers ?? []),
-            ...(formValues.advancedSettings?.fillers?.questionFillers ?? []),
-            ...(formValues.advancedSettings?.fillers?.ambiguousFillers ?? []),
-          ].some((w: string) => w !== ''),
-          language: formValues.advancedSettings?.fillers?.language ?? 'auto',
-          question_keywords: formValues.advancedSettings?.fillers?.questionKeywords?.filter((f: string) => f !== '') ?? [],
-          question_fillers: formValues.advancedSettings?.fillers?.questionFillers?.filter((f: string) => f !== '') ?? [],
-          ambiguous_keywords: formValues.advancedSettings?.fillers?.ambiguousKeywords?.filter((f: string) => f !== '') ?? [],
-          ambiguous_fillers: formValues.advancedSettings?.fillers?.ambiguousFillers?.filter((f: string) => f !== '') ?? [],
-          general_fillers: formValues.advancedSettings?.fillers?.generalFillers?.filter((f: string) => f !== '') ?? [],
-          typing_probability: formValues.advancedSettings?.backgroundAudio?.thinkingProbability ?? 0.10,
-          filler_cooldown_sec: formValues.advancedSettings?.fillers?.fillerCooldownSec ?? 4.0,
-          latency_threshold: formValues.advancedSettings?.fillers?.latencyThreshold ?? 1.2,
-          conversation_fillers: formValues.advancedSettings?.fillers?.conversationFillers?.filter((f: string) => f !== '') ?? [],
-          conversation_keywords: formValues.advancedSettings?.fillers?.conversationKeywords?.filter((f: string) => f !== '') ?? [],
-        },
-        bug_reports: {
-          enable: formValues.advancedSettings?.bugs?.enableBugReport ?? getFallback(null, 'bug_reports.enable'),
-          bug_start_command: formValues.advancedSettings?.bugs?.bugStartCommands || getFallback(null, 'bug_reports.bug_start_command'),
-          bug_end_command: formValues.advancedSettings?.bugs?.bugEndCommands || getFallback(null, 'bug_reports.bug_end_command'),
-          response: formValues.advancedSettings?.bugs?.initialResponse || getFallback(null, 'bug_reports.response'),
-          collection_prompt: formValues.advancedSettings?.bugs?.collectionPrompt || getFallback(null, 'bug_reports.collection_prompt')
-        },
-        context_memory: {
-          enabled: formValues.advancedSettings?.contextMemory?.enabled ?? false
-        },
-        interruptions: {
-          allow_interruptions: formValues.advancedSettings?.interruption?.allowInterruptions ?? getFallback(null, 'interruptions.allow_interruptions'),
-          min_interruption_duration: formValues.advancedSettings?.interruption?.minInterruptionDuration ?? getFallback(null, 'interruptions.min_interruption_duration'),
-          min_interruption_words: formValues.advancedSettings?.interruption?.minInterruptionWords ?? getFallback(null, 'interruptions.min_interruption_words'),
-          drop_filler_words: formValues.advancedSettings?.interruption?.dropFillerWords ?? false,
-          filler_drop_list: formValues.advancedSettings?.interruption?.fillerDropList ?? [],
-        },
-        ...getInterruptionModeFields(formValues),
-        ...(formValues.advancedSettings?.session?.interruption_mode === 'adaptive' && {
-          adaptive_min_duration: formValues.advancedSettings.interruption?.adaptiveMinDuration ?? 0.8,
-          adaptive_min_words: formValues.advancedSettings.interruption?.adaptiveMinWords ?? 0,
-          adaptive_discard_audio_if_uninterruptible: formValues.advancedSettings.interruption?.adaptiveDiscardAudioIfUninterruptible ?? true,
-          adaptive_resume_false_interruption: formValues.advancedSettings.interruption?.adaptiveResumeFalseInterruption ?? true,
-          adaptive_false_interruption_timeout: formValues.advancedSettings.interruption?.adaptiveFalseInterruptionTimeout ?? 0.5,
-          adaptive_backchannel_boundary_start: formValues.advancedSettings.interruption?.adaptiveBackchannelBoundaryStart ?? 0.1,
-          adaptive_backchannel_boundary_end: formValues.advancedSettings.interruption?.adaptiveBackchannelBoundaryEnd ?? 2,
-        }),
-        first_message_mode: firstMessageModeConfig,
-        first_message: firstMessageModeConfig.first_message,
-        turn_detection: formValues.advancedSettings?.session?.turn_detection || getFallback(null, 'session_behavior.turn_detection'),
-        session_behavior: {
-          preemptive_generation: formValues.advancedSettings?.session?.preemptiveGeneration || getFallback(null, 'session_behavior.preemptive_generation'),
-          turn_detection: formValues.advancedSettings?.session?.turn_detection || getFallback(null, 'session_behavior.turn_detection'),
-          unlikely_threshold: formValues.advancedSettings?.session?.unlikely_threshold ?? getFallback(null, 'session_behavior.unlikely_threshold'),
-          min_endpointing_delay: formValues.advancedSettings?.session?.min_endpointing_delay ?? getFallback(null, 'session_behavior.min_endpointing_delay'),
-          max_endpointing_delay: formValues.advancedSettings?.session?.max_endpointing_delay ?? getFallback(null, 'session_behavior.max_endpointing_delay'),
-          ...(formValues.advancedSettings?.session?.endpointing_mode && {
-            endpointing_mode: formValues.advancedSettings.session.endpointing_mode
-          }),
-          // interruption_mode is intentionally omitted here — it's sent at the top level
-          // above and the backend hoists it into session_behavior on save.
-          ...(formValues.advancedSettings?.session?.user_away_timeout !== undefined && {
-            user_away_timeout: formValues.advancedSettings.session.user_away_timeout
-          }),
-          ...(formValues.advancedSettings?.session?.user_away_timeout_message !== undefined && formValues.advancedSettings.session.user_away_timeout_message !== null && {
-            user_away_timeout_message: formValues.advancedSettings.session.user_away_timeout_message
-          }),
-          ...(formValues.advancedSettings?.session?.user_away_timeout_max_count !== undefined && {
-            user_away_timeout_max_count: formValues.advancedSettings.session.user_away_timeout_max_count
-          }),
-          ...(formValues.advancedSettings?.session?.user_away_timeout_end_message !== undefined && formValues.advancedSettings.session.user_away_timeout_end_message !== null && formValues.advancedSettings.session.user_away_timeout_end_message !== '' && {
-            user_away_timeout_end_message: formValues.advancedSettings.session.user_away_timeout_end_message
-          })
-        },
-        background_audio: {
-          enabled: formValues.advancedSettings?.backgroundAudio?.mode !== 'disabled',
-          thinking_probability: formValues.advancedSettings?.backgroundAudio?.thinkingProbability ?? 1.0,
-          tool_call_typing_config: {
-            enabled: formValues.advancedSettings?.backgroundAudio?.toolCallTyping ?? false,
-            volume: formValues.advancedSettings?.backgroundAudio?.toolCallVolume ?? 0.8
-          },
-          ...(formValues.advancedSettings?.backgroundAudio?.mode === 'single' && {
-            type: formValues.advancedSettings.backgroundAudio.singleType,
-            volume: formValues.advancedSettings.backgroundAudio.singleVolume,
-            timing: formValues.advancedSettings.backgroundAudio.singleTiming
-          }),
-          ...(formValues.advancedSettings?.backgroundAudio?.mode === 'dual' && {
-            ambient: {
-              type: formValues.advancedSettings.backgroundAudio.ambientType,
-              volume: formValues.advancedSettings.backgroundAudio.ambientVolume
-            },
-            thinking: {
-              type: formValues.advancedSettings.backgroundAudio.thinkingType,
-              volume: formValues.advancedSettings.backgroundAudio.thinkingVolume
-            }
-          })
-        },
-        ...(formValues.dynamic_tts && formValues.dynamic_tts.length > 0 && {
-          dynamic_tts: formValues.dynamic_tts
-        }),
-        fallback_global_enabled: !!formValues.fallbackGlobalEnabled,
-      }
+        useBackgroundAudioFallbacks: false,
+      })
     })
 
     return buildAgentEnvelope(agentName, agentType, assistants)

--- a/src/hooks/useMultiAssistantState.ts
+++ b/src/hooks/useMultiAssistantState.ts
@@ -166,27 +166,17 @@ function getInterruptionModeFields(formValues: any): { interruption_mode: string
   }
 }
 
-function buildAssistantPayload(formValues: any, opts: {
-  name: string
-  stt: any
-  llm: any
-  tts: any
-  tools: any
-  // Single-assistant and multi-assistant save paths disagree on whether
-  // background_audio's single/dual fields fall back to a default when the
-  // form value is empty (single-assistant does, multi-assistant doesn't) --
-  // a pre-existing behavioral difference, preserved here rather than
-  // silently unified.
-  useBackgroundAudioFallbacks: boolean
-}): any {
-  const variablesObject = Array.isArray(formValues.variables)
+function buildAssistantVariables(formValues: any): any {
+  return Array.isArray(formValues.variables)
     ? formValues.variables.reduce((acc: any, v: any) => {
         acc[v.name] = v.value
         return acc
       }, {})
     : formValues.variables || {}
+}
 
-  const firstMessageModeConfig = typeof formValues.firstMessageMode === 'object'
+function buildAssistantFirstMessageMode(formValues: any): any {
+  return typeof formValues.firstMessageMode === 'object'
     ? {
         mode: formValues.firstMessageMode.mode,
         first_message: formValues.firstMessageMode.first_message || '',
@@ -197,8 +187,69 @@ function buildAssistantPayload(formValues: any, opts: {
         first_message: formValues.customFirstMessage || getFallback(null, 'first_message_mode.first_message'),
         allow_interruptions: getFallback(null, 'first_message_mode.allow_interruptions')
       }
+}
 
-  const singleBackgroundAudio = opts.useBackgroundAudioFallbacks
+function buildAssistantVadPayload(formValues: any): any {
+  return {
+    name: formValues.advancedSettings?.vad?.vadProvider || getFallback(null, 'vad.name'),
+    ...(formValues.advancedSettings?.vad?.minSilenceDuration !== undefined && {
+      min_silence_duration: formValues.advancedSettings.vad.minSilenceDuration
+    }),
+    ...(formValues.advancedSettings?.vad?.minSpeechDuration !== undefined && {
+      min_speech_duration: formValues.advancedSettings.vad.minSpeechDuration
+    }),
+    ...(formValues.advancedSettings?.vad?.prefixPaddingDuration !== undefined && {
+      prefix_padding_duration: formValues.advancedSettings.vad.prefixPaddingDuration
+    }),
+    ...(formValues.advancedSettings?.vad?.maxBufferedSpeech !== undefined && {
+      max_buffered_speech: formValues.advancedSettings.vad.maxBufferedSpeech
+    }),
+    ...(formValues.advancedSettings?.vad?.activationThreshold !== undefined && {
+      activation_threshold: formValues.advancedSettings.vad.activationThreshold
+    }),
+    ...(formValues.advancedSettings?.vad?.sampleRate !== undefined && {
+      sample_rate: formValues.advancedSettings.vad.sampleRate
+    }),
+    ...(formValues.advancedSettings?.vad?.forceCpu !== undefined && {
+      force_cpu: formValues.advancedSettings.vad.forceCpu
+    })
+  }
+}
+
+function buildAssistantSessionBehaviorPayload(formValues: any): any {
+  return {
+    preemptive_generation: formValues.advancedSettings?.session?.preemptiveGeneration || getFallback(null, 'session_behavior.preemptive_generation'),
+    turn_detection: formValues.advancedSettings?.session?.turn_detection || getFallback(null, 'session_behavior.turn_detection'),
+    unlikely_threshold: formValues.advancedSettings?.session?.unlikely_threshold ?? getFallback(null, 'session_behavior.unlikely_threshold'),
+    min_endpointing_delay: formValues.advancedSettings?.session?.min_endpointing_delay ?? getFallback(null, 'session_behavior.min_endpointing_delay'),
+    max_endpointing_delay: formValues.advancedSettings?.session?.max_endpointing_delay ?? getFallback(null, 'session_behavior.max_endpointing_delay'),
+    ...(formValues.advancedSettings?.session?.endpointing_mode && {
+      endpointing_mode: formValues.advancedSettings.session.endpointing_mode
+    }),
+    // interruption_mode is intentionally omitted here — it's sent at the top level
+    // above and the backend hoists it into session_behavior on save.
+    ...(formValues.advancedSettings?.session?.user_away_timeout !== undefined && {
+      user_away_timeout: formValues.advancedSettings.session.user_away_timeout
+    }),
+    ...(formValues.advancedSettings?.session?.user_away_timeout_message !== undefined && formValues.advancedSettings.session.user_away_timeout_message !== null && {
+      user_away_timeout_message: formValues.advancedSettings.session.user_away_timeout_message
+    }),
+    ...(formValues.advancedSettings?.session?.user_away_timeout_max_count !== undefined && {
+      user_away_timeout_max_count: formValues.advancedSettings.session.user_away_timeout_max_count
+    }),
+    ...(formValues.advancedSettings?.session?.user_away_timeout_end_message !== undefined && formValues.advancedSettings.session.user_away_timeout_end_message !== null && formValues.advancedSettings.session.user_away_timeout_end_message !== '' && {
+      user_away_timeout_end_message: formValues.advancedSettings.session.user_away_timeout_end_message
+    })
+  }
+}
+
+// Single-assistant and multi-assistant save paths disagree on whether
+// background_audio's single/dual fields fall back to a default when the
+// form value is empty (single-assistant does, multi-assistant doesn't) --
+// a pre-existing behavioral difference, preserved here via useFallbacks
+// rather than silently unified.
+function buildAssistantBackgroundAudioPayload(formValues: any, useFallbacks: boolean): any {
+  const singleBackgroundAudio = useFallbacks
     ? {
         type: formValues.advancedSettings?.backgroundAudio?.singleType || 'keyboard',
         volume: formValues.advancedSettings?.backgroundAudio?.singleVolume ?? 0.5,
@@ -210,7 +261,7 @@ function buildAssistantPayload(formValues: any, opts: {
         timing: formValues.advancedSettings?.backgroundAudio?.singleTiming
       }
 
-  const dualBackgroundAudio = opts.useBackgroundAudioFallbacks
+  const dualBackgroundAudio = useFallbacks
     ? {
         ambient: {
           type: formValues.advancedSettings?.backgroundAudio?.ambientType || getFallback(null, 'background_audio.ambient.type'),
@@ -233,36 +284,35 @@ function buildAssistantPayload(formValues: any, opts: {
       }
 
   return {
+    enabled: formValues.advancedSettings?.backgroundAudio?.mode !== 'disabled',
+    thinking_probability: formValues.advancedSettings?.backgroundAudio?.thinkingProbability ?? 1,
+    tool_call_typing_config: {
+      enabled: formValues.advancedSettings?.backgroundAudio?.toolCallTyping ?? false,
+      volume: formValues.advancedSettings?.backgroundAudio?.toolCallVolume ?? 0.8
+    },
+    ...(formValues.advancedSettings?.backgroundAudio?.mode === 'single' && singleBackgroundAudio),
+    ...(formValues.advancedSettings?.backgroundAudio?.mode === 'dual' && dualBackgroundAudio)
+  }
+}
+
+function buildAssistantPayload(formValues: any, opts: {
+  name: string
+  stt: any
+  llm: any
+  tts: any
+  tools: any
+  useBackgroundAudioFallbacks: boolean
+}): any {
+  const firstMessageModeConfig = buildAssistantFirstMessageMode(formValues)
+
+  return {
     name: opts.name,
     prompt: formValues.prompt || '',
-    variables: variablesObject,
+    variables: buildAssistantVariables(formValues),
     stt: opts.stt,
     llm: opts.llm,
     tts: opts.tts,
-    vad: {
-      name: formValues.advancedSettings?.vad?.vadProvider || getFallback(null, 'vad.name'),
-      ...(formValues.advancedSettings?.vad?.minSilenceDuration !== undefined && {
-        min_silence_duration: formValues.advancedSettings.vad.minSilenceDuration
-      }),
-      ...(formValues.advancedSettings?.vad?.minSpeechDuration !== undefined && {
-        min_speech_duration: formValues.advancedSettings.vad.minSpeechDuration
-      }),
-      ...(formValues.advancedSettings?.vad?.prefixPaddingDuration !== undefined && {
-        prefix_padding_duration: formValues.advancedSettings.vad.prefixPaddingDuration
-      }),
-      ...(formValues.advancedSettings?.vad?.maxBufferedSpeech !== undefined && {
-        max_buffered_speech: formValues.advancedSettings.vad.maxBufferedSpeech
-      }),
-      ...(formValues.advancedSettings?.vad?.activationThreshold !== undefined && {
-        activation_threshold: formValues.advancedSettings.vad.activationThreshold
-      }),
-      ...(formValues.advancedSettings?.vad?.sampleRate !== undefined && {
-        sample_rate: formValues.advancedSettings.vad.sampleRate
-      }),
-      ...(formValues.advancedSettings?.vad?.forceCpu !== undefined && {
-        force_cpu: formValues.advancedSettings.vad.forceCpu
-      })
-    },
+    vad: buildAssistantVadPayload(formValues),
     tools: opts.tools,
     filler_words: {
       enabled: (formValues.advancedSettings?.fillers?.enableFillerWords ?? false) && [
@@ -276,8 +326,8 @@ function buildAssistantPayload(formValues: any, opts: {
       ambiguous_keywords: formValues.advancedSettings?.fillers?.ambiguousKeywords?.filter((f: string) => f !== '') ?? [],
       ambiguous_fillers: formValues.advancedSettings?.fillers?.ambiguousFillers?.filter((f: string) => f !== '') ?? [],
       general_fillers: formValues.advancedSettings?.fillers?.generalFillers?.filter((f: string) => f !== '') ?? [],
-      typing_probability: formValues.advancedSettings?.backgroundAudio?.thinkingProbability ?? 0.10,
-      filler_cooldown_sec: formValues.advancedSettings?.fillers?.fillerCooldownSec ?? 4.0,
+      typing_probability: formValues.advancedSettings?.backgroundAudio?.thinkingProbability ?? 0.1,
+      filler_cooldown_sec: formValues.advancedSettings?.fillers?.fillerCooldownSec ?? 4,
       latency_threshold: formValues.advancedSettings?.fillers?.latencyThreshold ?? 1.2,
       conversation_fillers: formValues.advancedSettings?.fillers?.conversationFillers?.filter((f: string) => f !== '') ?? [],
       conversation_keywords: formValues.advancedSettings?.fillers?.conversationKeywords?.filter((f: string) => f !== '') ?? [],
@@ -312,40 +362,8 @@ function buildAssistantPayload(formValues: any, opts: {
     first_message_mode: firstMessageModeConfig,
     first_message: firstMessageModeConfig.first_message,
     turn_detection: formValues.advancedSettings?.session?.turn_detection || getFallback(null, 'session_behavior.turn_detection'),
-    session_behavior: {
-      preemptive_generation: formValues.advancedSettings?.session?.preemptiveGeneration || getFallback(null, 'session_behavior.preemptive_generation'),
-      turn_detection: formValues.advancedSettings?.session?.turn_detection || getFallback(null, 'session_behavior.turn_detection'),
-      unlikely_threshold: formValues.advancedSettings?.session?.unlikely_threshold ?? getFallback(null, 'session_behavior.unlikely_threshold'),
-      min_endpointing_delay: formValues.advancedSettings?.session?.min_endpointing_delay ?? getFallback(null, 'session_behavior.min_endpointing_delay'),
-      max_endpointing_delay: formValues.advancedSettings?.session?.max_endpointing_delay ?? getFallback(null, 'session_behavior.max_endpointing_delay'),
-      ...(formValues.advancedSettings?.session?.endpointing_mode && {
-        endpointing_mode: formValues.advancedSettings.session.endpointing_mode
-      }),
-      // interruption_mode is intentionally omitted here — it's sent at the top level
-      // above and the backend hoists it into session_behavior on save.
-      ...(formValues.advancedSettings?.session?.user_away_timeout !== undefined && {
-        user_away_timeout: formValues.advancedSettings.session.user_away_timeout
-      }),
-      ...(formValues.advancedSettings?.session?.user_away_timeout_message !== undefined && formValues.advancedSettings.session.user_away_timeout_message !== null && {
-        user_away_timeout_message: formValues.advancedSettings.session.user_away_timeout_message
-      }),
-      ...(formValues.advancedSettings?.session?.user_away_timeout_max_count !== undefined && {
-        user_away_timeout_max_count: formValues.advancedSettings.session.user_away_timeout_max_count
-      }),
-      ...(formValues.advancedSettings?.session?.user_away_timeout_end_message !== undefined && formValues.advancedSettings.session.user_away_timeout_end_message !== null && formValues.advancedSettings.session.user_away_timeout_end_message !== '' && {
-        user_away_timeout_end_message: formValues.advancedSettings.session.user_away_timeout_end_message
-      })
-    },
-    background_audio: {
-      enabled: formValues.advancedSettings?.backgroundAudio?.mode !== 'disabled',
-      thinking_probability: formValues.advancedSettings?.backgroundAudio?.thinkingProbability ?? 1.0,
-      tool_call_typing_config: {
-        enabled: formValues.advancedSettings?.backgroundAudio?.toolCallTyping ?? false,
-        volume: formValues.advancedSettings?.backgroundAudio?.toolCallVolume ?? 0.8
-      },
-      ...(formValues.advancedSettings?.backgroundAudio?.mode === 'single' && singleBackgroundAudio),
-      ...(formValues.advancedSettings?.backgroundAudio?.mode === 'dual' && dualBackgroundAudio)
-    },
+    session_behavior: buildAssistantSessionBehaviorPayload(formValues),
+    background_audio: buildAssistantBackgroundAudioPayload(formValues, opts.useBackgroundAudioFallbacks),
     ...(formValues.dynamic_tts && formValues.dynamic_tts.length > 0 && {
       dynamic_tts: formValues.dynamic_tts
     }),

--- a/src/hooks/useMultiAssistantState.ts
+++ b/src/hooks/useMultiAssistantState.ts
@@ -157,8 +157,13 @@ function buildFallbackTtsPayload(formValues: any) {
   }
 }
 
-function getRealInterruptionGuard(formValues: any): boolean {
-  return formValues.advancedSettings?.interruption?.realInterruptionGuard ?? false
+function getInterruptionModeFields(formValues: any): { interruption_mode: string | null; adaptive_stt: boolean; real_interruption_guard: boolean } {
+  const interruption_mode = formValues.advancedSettings?.session?.interruption_mode ?? null
+  return {
+    interruption_mode,
+    adaptive_stt: interruption_mode === 'adaptive',
+    real_interruption_guard: formValues.advancedSettings?.interruption?.realInterruptionGuard ?? false,
+  }
 }
 
 function buildSingleAssistantSttPayload(formValues: any, currentSttConfig: any): any {
@@ -697,9 +702,7 @@ export function useMultiAssistantState({
           drop_filler_words: formValues.advancedSettings?.interruption?.dropFillerWords ?? false,
           filler_drop_list: formValues.advancedSettings?.interruption?.fillerDropList ?? [],
         },
-        interruption_mode: formValues.advancedSettings?.session?.interruption_mode ?? null,
-        adaptive_stt: formValues.advancedSettings?.session?.interruption_mode === 'adaptive',
-        real_interruption_guard: getRealInterruptionGuard(formValues),
+        ...getInterruptionModeFields(formValues),
         ...(formValues.advancedSettings?.session?.interruption_mode === 'adaptive' && {
           adaptive_min_duration: formValues.advancedSettings.interruption?.adaptiveMinDuration ?? 0.8,
           adaptive_min_words: formValues.advancedSettings.interruption?.adaptiveMinWords ?? 0,
@@ -909,9 +912,7 @@ export function useMultiAssistantState({
           drop_filler_words: formValues.advancedSettings?.interruption?.dropFillerWords ?? false,
           filler_drop_list: formValues.advancedSettings?.interruption?.fillerDropList ?? [],
         },
-        interruption_mode: formValues.advancedSettings?.session?.interruption_mode ?? null,
-        adaptive_stt: formValues.advancedSettings?.session?.interruption_mode === 'adaptive',
-        real_interruption_guard: getRealInterruptionGuard(formValues),
+        ...getInterruptionModeFields(formValues),
         ...(formValues.advancedSettings?.session?.interruption_mode === 'adaptive' && {
           adaptive_min_duration: formValues.advancedSettings.interruption?.adaptiveMinDuration ?? 0.8,
           adaptive_min_words: formValues.advancedSettings.interruption?.adaptiveMinWords ?? 0,

--- a/src/utils/agentConfigSerializer.ts
+++ b/src/utils/agentConfigSerializer.ts
@@ -83,7 +83,7 @@ export interface SerializedAgentConfig {
       }
       session: {
         preemptiveGeneration: 'disabled' | 'enabled'
-        turn_detection: 'multilingual' | 'english' | 'smollm2turndetector' | 'llmturndetector' | 'smollm360m' | 'disabled'
+        turn_detection: 'multilingual' | 'english' | 'disabled'
         unlikely_threshold?: number
         min_endpointing_delay?: number
         max_endpointing_delay?: number


### PR DESCRIPTION
## Summary
Adds a heuristic classifier ("real-interruption guard") that decides whether an
overlap during agent speech is a genuine attempt to take the floor vs. a
filler/backchannel word or stray noise — replacing the SDK's default
"any final transcript overlapping agent speech = interrupt" behavior for
agents that opt in. Ships disabled by default for every existing and new
agent; only takes effect when explicitly enabled via the frontend's Real
Interruption Guard toggle.

## New files
- `utils/real_interruption_classifier.py` — pure, framework-free scoring
  logic (no LiveKit imports). Fuses lexical (filler/backchannel/content-signal
  word lists, EN/HI/KN), temporal (overlap timing, gap between repeated
  attempts), and collision-history signals into a score. Includes a
  reply gate that separately decides whether a confirmed interruption also
  spawns a fresh LLM+TTS reply, or just silently cancels the agent's speech.
- `utils/interruption_guard.py` — wires the classifier into LiveKit by
  monkeypatching `AgentActivity.on_final_transcript`/`on_end_of_turn`/
  `_interrupt_by_audio_activity` and `AudioRecognition._on_start_of_agent_speech`.
  Global patch at import time, gated per-agent-instance at call time.

## Wiring
- `utils/create_agent.py` — calls `install_real_interruption_guard()` once
  at import; writes `_real_interruption_guard_enabled` (from the assistant's
  stored config) plus classifier state and three per-call rollup counters
  (`dropped`, `real_interruption`, `gated_no_reply`) into every generated
  agent's `__init__`.
- `entrypoint.py` — `_inject_real_interruption_stats()` writes those three
  counters into Whispey's `dynamic_params`/cached metadata at export time
  (both export paths), gated on the feature actually being enabled for that
  agent — a no-op for everyone else.
- Mutually exclusive with `interruption_mode=adaptive` (LiveKit's own ML
  interruption detector) — checked live on every classifier call via
  `Agent._interruption_detection`, not just at session start, so it also
  correctly disables itself if a mid-call language-switch tool flips the
  agent into adaptive mode.

## Related cleanup in this branch
- Removes the old turn-detector models (`CustomEOU.py`/`LLMEOU.py`/
  `SmolLM360M.py`) and their prewarming logic in `main.py`, replaced by a
  single `v1-mini` turn-detection option recommended alongside the guard.
- Language-switch tool templates updated for the new turn-detector option.
- Minor: Sarvam STT default model bumped `saarika:v2` → `saarika:v3`
  (`workflow/providers.py`).

## Testing
Extensively tested against live local calls across multiple rounds — see
commit history for the specific classifier tuning fixes (collision-count
bootstrap, word-count-tier merge inflation, reply-gate/skip_reply
interaction, filler-persistence escalation, etc)

## Notes for reviewers
- `real_interruption_guard.py`'s decisions are logged in full
  (`[real-interruption] stage=... decision=... score=... features=...`)
  for every call where the feature is enabled — useful for verifying
  behavior on real traffic before wider rollout.
- The counterpart Whispey SDK change (a proper `record_interruption_event`
  field, for a future v2 of per-word transcript markers) is tracked
  separately, not part of this PR.