### PR TITLE
Fix/project role multi match

### DIFF
--- a/src/app/api/admin/users/[userId]/agent-access/route.ts
+++ b/src/app/api/admin/users/[userId]/agent-access/route.ts
@@ -155,12 +155,16 @@ export async function PATCH(
     return NextResponse.json({ error: 'User not found' }, { status: 404 })
   }
 
+  // .limit(1): this match is deliberately broad (clerk_id OR email, same as
+  // the list query above), so a target user with dual accounts sharing this
+  // email must not turn "found a mapping" into a 500.
   const { data: mapping, error: mappingErr } = await supabase
     .from('pype_voice_email_project_mapping')
     .select('id, permissions')
     .eq('project_id', projectId)
     .or(`clerk_id.eq.${targetUser.clerk_id},email.ilike.${targetUser.email}`)
     .or('is_active.is.null,is_active.eq.true')
+    .limit(1)
     .maybeSingle()
 
   if (mappingErr || !mapping) {

--- a/src/app/api/agent-config-by-log-id/[logId]/route.ts
+++ b/src/app/api/agent-config-by-log-id/[logId]/route.ts
@@ -3,6 +3,8 @@ import { DynamoDBClient, GetItemCommand } from "@aws-sdk/client-dynamodb"
 import { auth, currentUser } from "@clerk/nextjs/server"
 import { createServiceRoleClient } from "@/lib/supabase-server"
 import { getCallerGlobalRole } from "@/lib/prod-auth"
+import { projectMembershipMatch } from "@/lib/getProjectRoleForApi"
+import { isPlatformAdmin } from "@/lib/isPlatformAdmin"
 
 const REGION = process.env.AWS_REGION || "ap-south-1"
 const CALL_CONFIG_TABLE = (process.env.CALL_CONFIG_TABLE || `call-log-agent-config-${process.env.STAGE || "dev"}`).trim()
@@ -68,12 +70,16 @@ export async function GET(
         return NextResponse.json({ message: "Admin access required" }, { status: 403 })
       }
 
+      // .limit(1) before .maybeSingle(): an admin's match is deliberately
+      // broad (clerk_id OR email), so a legitimate multi-row match (dual
+      // accounts sharing this email) must not turn "yes, a member" into a 500.
       const { data: userAccessMapping, error: accessError } = await supabase
         .from("pype_voice_email_project_mapping")
         .select("role, is_active")
         .eq("project_id", projectId)
-        .or(`clerk_id.eq.${userId},email.ilike.${userEmail}`)
+        .or(projectMembershipMatch(userId, userEmail, isPlatformAdmin(userEmail)))
         .or("is_active.is.null,is_active.eq.true")
+        .limit(1)
         .maybeSingle()
 
       if (accessError) {

--- a/src/app/api/projects/[id]/me/route.ts
+++ b/src/app/api/projects/[id]/me/route.ts
@@ -5,6 +5,8 @@ import { NextRequest, NextResponse } from 'next/server'
 import { auth, currentUser } from '@clerk/nextjs/server'
 import { getEffectiveVisibility } from '@/types/visibility'
 import { createServiceRoleClient } from '@/lib/supabase-server'
+import { projectMembershipMatch } from '@/lib/getProjectRoleForApi'
+import { isPlatformAdmin } from '@/lib/isPlatformAdmin'
 
 const supabase = createServiceRoleClient()
 
@@ -32,8 +34,13 @@ export async function GET(
         .from('pype_voice_email_project_mapping')
         .select('role, permissions, is_active')
         .eq('project_id', projectId)
-        .or(`clerk_id.eq.${userId},email.ilike.${userEmail}`)
+        // .limit(1) before .maybeSingle(): without it, a legitimate multi-row
+        // match (e.g. the same email tied to two different accounts/domains)
+        // makes Supabase error out instead of returning a row, surfacing as
+        // a 500 here rather than "yes, a member."
+        .or(projectMembershipMatch(userId, userEmail, isPlatformAdmin(userEmail)))
         .or('is_active.is.null,is_active.eq.true')
+        .limit(1)
         .maybeSingle(),
       supabase
         .from('pype_voice_users')

--- a/src/app/api/projects/[id]/members/[memberId]/route.ts
+++ b/src/app/api/projects/[id]/members/[memberId]/route.ts
@@ -13,6 +13,38 @@ function normalizeRole(role: string): string {
   return role
 }
 
+type MappingAccessRow = { role: string; clerk_id: string | null; email: string; is_active: boolean | null }
+
+// Shared by PATCH and DELETE: does the caller have admin/owner access to this project?
+// .limit(1) before .maybeSingle(): an admin's match is deliberately broad (clerk_id
+// OR email), so a legitimate multi-row match (dual accounts sharing this email) must
+// not turn "yes, a member" into a 500.
+async function requireProjectAdminAccess(
+  projectId: string,
+  userId: string,
+  userEmail: string | undefined
+): Promise<{ mapping: MappingAccessRow } | { errorResponse: NextResponse }> {
+  const { data: userAccessMapping, error: accessError } = await supabase
+    .from('pype_voice_email_project_mapping')
+    .select('role, clerk_id, email, is_active')
+    .eq('project_id', projectId)
+    .or(projectMembershipMatch(userId, userEmail, isPlatformAdmin(userEmail)))
+    .or('is_active.is.null,is_active.eq.true')
+    .limit(1)
+    .maybeSingle()
+
+  if (accessError) {
+    console.error('Error checking user access:', accessError)
+    return { errorResponse: NextResponse.json({ error: 'Internal server error' }, { status: 500 }) }
+  }
+
+  if (!userAccessMapping || !['admin', 'owner'].includes(userAccessMapping.role)) {
+    return { errorResponse: NextResponse.json({ error: 'Admin access required' }, { status: 403 }) }
+  }
+
+  return { mapping: userAccessMapping }
+}
+
 export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string; memberId: string }> }
@@ -41,27 +73,11 @@ export async function PATCH(
       return NextResponse.json({ error: 'Invalid role' }, { status: 400 })
     }
 
-    // ✅ FIXED: Check if current user has admin/owner access (only active mappings)
-    // .limit(1) before .maybeSingle(): an admin's match is deliberately broad
-    // (clerk_id OR email), so a legitimate multi-row match (dual accounts
-    // sharing this email) must not turn "yes, a member" into a 500.
-    const { data: userAccessMapping, error: accessError } = await supabase
-      .from('pype_voice_email_project_mapping')
-      .select('role, clerk_id, email, is_active')
-      .eq('project_id', projectId)
-      .or(projectMembershipMatch(userId, userEmail, isPlatformAdmin(userEmail)))
-      .or('is_active.is.null,is_active.eq.true')
-      .limit(1)
-      .maybeSingle()
-
-    if (accessError) {
-      console.error('Error checking user access:', accessError)
-      return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+    const access = await requireProjectAdminAccess(projectId, userId, userEmail)
+    if ('errorResponse' in access) {
+      return access.errorResponse
     }
-
-    if (!userAccessMapping || !['admin', 'owner'].includes(userAccessMapping.role)) {
-      return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
-    }
+    const { mapping: userAccessMapping } = access
 
     // Normalize the role early
     const newRole = normalizeRole(role)
@@ -160,26 +176,9 @@ export async function DELETE(
     const { searchParams } = new URL(request.url)
     const permanent = searchParams.get('permanent') === 'true'
 
-    // ✅ FIXED: Check if current user has admin/owner access (only active mappings)
-    // .limit(1) before .maybeSingle(): an admin's match is deliberately broad
-    // (clerk_id OR email), so a legitimate multi-row match (dual accounts
-    // sharing this email) must not turn "yes, a member" into a 500.
-    const { data: userAccessMapping, error: accessError } = await supabase
-      .from('pype_voice_email_project_mapping')
-      .select('role, clerk_id, email, is_active')
-      .eq('project_id', projectId)
-      .or(projectMembershipMatch(userId, userEmail, isPlatformAdmin(userEmail)))
-      .or('is_active.is.null,is_active.eq.true')
-      .limit(1)
-      .maybeSingle()
-
-    if (accessError) {
-      console.error('Error checking user access:', accessError)
-      return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
-    }
-
-    if (!userAccessMapping || !['admin', 'owner'].includes(userAccessMapping.role)) {
-      return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
+    const access = await requireProjectAdminAccess(projectId, userId, userEmail)
+    if ('errorResponse' in access) {
+      return access.errorResponse
     }
 
     // ✅ FIXED: Get the member to delete (check ALL records, not just active)

--- a/src/app/api/projects/[id]/members/[memberId]/route.ts
+++ b/src/app/api/projects/[id]/members/[memberId]/route.ts
@@ -3,6 +3,8 @@ import { NextRequest, NextResponse } from 'next/server'
 import { auth, currentUser } from '@clerk/nextjs/server'
 import { DEFAULT_MEMBER_VISIBILITY, VIEWER_RESTRICTED_VISIBILITY } from '@/types/visibility'
 import { createServiceRoleClient } from '@/lib/supabase-server'
+import { projectMembershipMatch } from '@/lib/getProjectRoleForApi'
+import { isPlatformAdmin } from '@/lib/isPlatformAdmin'
 
 const supabase = createServiceRoleClient()
 
@@ -40,12 +42,16 @@ export async function PATCH(
     }
 
     // ✅ FIXED: Check if current user has admin/owner access (only active mappings)
+    // .limit(1) before .maybeSingle(): an admin's match is deliberately broad
+    // (clerk_id OR email), so a legitimate multi-row match (dual accounts
+    // sharing this email) must not turn "yes, a member" into a 500.
     const { data: userAccessMapping, error: accessError } = await supabase
       .from('pype_voice_email_project_mapping')
       .select('role, clerk_id, email, is_active')
       .eq('project_id', projectId)
-      .or(`clerk_id.eq.${userId},email.ilike.${userEmail}`)
+      .or(projectMembershipMatch(userId, userEmail, isPlatformAdmin(userEmail)))
       .or('is_active.is.null,is_active.eq.true')
+      .limit(1)
       .maybeSingle()
 
     if (accessError) {
@@ -155,12 +161,16 @@ export async function DELETE(
     const permanent = searchParams.get('permanent') === 'true'
 
     // ✅ FIXED: Check if current user has admin/owner access (only active mappings)
+    // .limit(1) before .maybeSingle(): an admin's match is deliberately broad
+    // (clerk_id OR email), so a legitimate multi-row match (dual accounts
+    // sharing this email) must not turn "yes, a member" into a 500.
     const { data: userAccessMapping, error: accessError } = await supabase
       .from('pype_voice_email_project_mapping')
       .select('role, clerk_id, email, is_active')
       .eq('project_id', projectId)
-      .or(`clerk_id.eq.${userId},email.ilike.${userEmail}`)
+      .or(projectMembershipMatch(userId, userEmail, isPlatformAdmin(userEmail)))
       .or('is_active.is.null,is_active.eq.true')
+      .limit(1)
       .maybeSingle()
 
     if (accessError) {

--- a/src/app/api/projects/[id]/members/[memberId]/route.ts
+++ b/src/app/api/projects/[id]/members/[memberId]/route.ts
@@ -111,8 +111,7 @@ export async function PATCH(
     }
 
     // Don't allow changing your own role (but allow changing own visibility for future use)
-    const isSelf = memberToUpdate.clerk_id === userId || memberToUpdate.email?.toLowerCase() === userEmail?.toLowerCase()
-    if (role && isSelf) {
+    if (role && isSameUser(memberToUpdate, userId, userEmail)) {
       return NextResponse.json({ error: 'You cannot change your own role' }, { status: 400 })
     }
 
@@ -157,6 +156,41 @@ export async function PATCH(
   }
 }
 
+function isSameUser(mapping: { clerk_id: string | null; email: string | null }, userId: string, userEmail: string | undefined): boolean {
+  return mapping.clerk_id === userId || mapping.email?.toLowerCase() === userEmail?.toLowerCase()
+}
+
+// Permanently removes the mapping row (used for pending invites, so the invite
+// token stops working, and for an explicit "permanent" delete of an active member).
+async function hardDeleteMapping(memberId: string, projectId: string): Promise<NextResponse | null> {
+  const { error } = await supabase
+    .from('pype_voice_email_project_mapping')
+    .delete()
+    .eq('id', memberId)
+    .eq('project_id', projectId)
+
+  if (error) {
+    console.error('Error deleting member:', error)
+    return NextResponse.json({ error: 'Failed to remove member' }, { status: 500 })
+  }
+  return null
+}
+
+// Deactivates an active member's mapping row without deleting it, so they can be re-added later.
+async function softDeleteMapping(memberId: string, projectId: string): Promise<NextResponse | null> {
+  const { error } = await supabase
+    .from('pype_voice_email_project_mapping')
+    .update({ is_active: false })
+    .eq('id', memberId)
+    .eq('project_id', projectId)
+
+  if (error) {
+    console.error('Error soft deleting member:', error)
+    return NextResponse.json({ error: 'Failed to remove member' }, { status: 500 })
+  }
+  return null
+}
+
 export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ id: string; memberId: string }> }
@@ -164,17 +198,14 @@ export async function DELETE(
   try {
     const { userId } = await auth()
     const user = await currentUser()
-    
+
     if (!userId) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
     const { id: projectId, memberId } = await params
     const userEmail = user?.emailAddresses?.[0]?.emailAddress
-
-    // Get permanent flag from query params
-    const { searchParams } = new URL(request.url)
-    const permanent = searchParams.get('permanent') === 'true'
+    const permanent = new URL(request.url).searchParams.get('permanent') === 'true'
 
     const access = await requireProjectAdminAccess(projectId, userId, userEmail)
     if ('errorResponse' in access) {
@@ -202,8 +233,7 @@ export async function DELETE(
       return NextResponse.json({ error: 'Cannot remove project owner' }, { status: 400 })
     }
 
-    // Don't allow removing yourself
-    if (memberToDelete.clerk_id === userId || memberToDelete.email?.toLowerCase() === userEmail?.toLowerCase()) {
+    if (isSameUser(memberToDelete, userId, userEmail)) {
       return NextResponse.json({ error: 'You cannot remove yourself' }, { status: 400 })
     }
 
@@ -213,39 +243,26 @@ export async function DELETE(
     const isPendingInvite = !memberToDelete.clerk_id
 
     if (isPendingInvite || permanent) {
-      const { error: deleteError } = await supabase
-        .from('pype_voice_email_project_mapping')
-        .delete()
-        .eq('id', memberId)
-        .eq('project_id', projectId)
-
-      if (deleteError) {
-        console.error('Error deleting member:', deleteError)
-        return NextResponse.json({ error: 'Failed to remove member' }, { status: 500 })
+      const errorResponse = await hardDeleteMapping(memberId, projectId)
+      if (errorResponse) {
+        return errorResponse
       }
 
-      return NextResponse.json({ 
+      return NextResponse.json({
         message: isPendingInvite ? 'Invite cancelled' : 'Member permanently removed',
         type: isPendingInvite ? 'invite_cancelled' : 'permanent_delete',
       }, { status: 200 })
-    } else {
-      // Soft delete active members — preserves history and allows re-adding
-      const { error: deleteError } = await supabase
-        .from('pype_voice_email_project_mapping')
-        .update({ is_active: false })
-        .eq('id', memberId)
-        .eq('project_id', projectId)
-
-      if (deleteError) {
-        console.error('Error soft deleting member:', deleteError)
-        return NextResponse.json({ error: 'Failed to remove member' }, { status: 500 })
-      }
-
-      return NextResponse.json({ 
-        message: 'Member access removed',
-        type: 'soft_delete'
-      }, { status: 200 })
     }
+
+    const errorResponse = await softDeleteMapping(memberId, projectId)
+    if (errorResponse) {
+      return errorResponse
+    }
+
+    return NextResponse.json({
+      message: 'Member access removed',
+      type: 'soft_delete'
+    }, { status: 200 })
   } catch (error) {
     console.error('Unexpected error removing member:', error)
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })

--- a/src/app/api/projects/[id]/members/route.ts
+++ b/src/app/api/projects/[id]/members/route.ts
@@ -5,6 +5,8 @@ import { randomUUID } from 'crypto'
 import { DEFAULT_MEMBER_VISIBILITY, VIEWER_RESTRICTED_VISIBILITY } from '@/types/visibility'
 import { createServiceRoleClient } from '@/lib/supabase-server'
 import { sendInviteEmail } from '@/lib/sendInviteEmail'
+import { projectMembershipMatch } from '@/lib/getProjectRoleForApi'
+import { isPlatformAdmin } from '@/lib/isPlatformAdmin'
 
 const supabase = createServiceRoleClient()
 
@@ -61,16 +63,18 @@ export async function POST(
 
     const userEmail = user?.emailAddresses?.[0]?.emailAddress
     
-    // Check current user access
+    // Check current user access. Scoped the same way as everywhere else:
+    // non-admins only match their own clerk_id (or an unclaimed new-domain
+    // invite), so a stale row from a different account sharing this email
+    // can't grant invite/admin rights here.
     const { data: allMappings } = await supabase
       .from('pype_voice_email_project_mapping')
       .select('role, clerk_id, email')
       .eq('project_id', projectId)
+      .or(projectMembershipMatch(userId, userEmail, isPlatformAdmin(userEmail)))
       .or('is_active.is.null,is_active.eq.true')
 
-    const userMapping = allMappings?.find(
-      (m: any) => m.clerk_id === userId || m.email?.toLowerCase() === userEmail?.toLowerCase()
-    )
+    const userMapping = allMappings?.find((m: any) => ['admin', 'owner'].includes(m.role))
 
     if (!userMapping || !['admin', 'owner'].includes(userMapping.role)) {
       return NextResponse.json(
@@ -296,12 +300,16 @@ export async function GET(
     const userEmail = user?.emailAddresses?.[0]?.emailAddress
 
     // ✅ FIXED: Check if user has ANY access to the project (not just admin)
+    // .limit(1) before .maybeSingle(): an admin's match is deliberately broad
+    // (clerk_id OR email), so a legitimate multi-row match (dual accounts
+    // sharing this email) must not turn "yes, a member" into a 500.
     const { data: userAccessMapping, error: accessError } = await supabase
       .from('pype_voice_email_project_mapping')
       .select('role, clerk_id, email, is_active')
       .eq('project_id', projectId)
-      .or(`clerk_id.eq.${userId},email.ilike.${userEmail}`)
+      .or(projectMembershipMatch(userId, userEmail, isPlatformAdmin(userEmail)))
       .or('is_active.is.null,is_active.eq.true')
+      .limit(1)
       .maybeSingle()
 
     if (accessError) {

--- a/src/app/api/projects/[id]/members/route.ts
+++ b/src/app/api/projects/[id]/members/route.ts
@@ -93,12 +93,15 @@ export async function POST(
     const orgName = project?.name ?? 'your organization'
     const appUrl = (process.env.NEXT_PUBLIC_APP_URL ?? 'https://www.whispey.xyz').replace(/\/$/, '')
 
-    // Check if already added by email (INCLUDING INACTIVE ONES)
+    // Check if already added by email (INCLUDING INACTIVE ONES).
+    // .limit(1): if this email was ever added to this exact project under two
+    // different clerk_ids (dual-domain account), this must not 500 on that.
     const { data: existingMapping, error: existingMappingError } = await supabase
       .from('pype_voice_email_project_mapping')
       .select('id, is_active, clerk_id, invite_token')
       .eq('email', normalizedEmail)
       .eq('project_id', projectId)
+      .limit(1)
       .maybeSingle()
 
     if (existingMappingError) {

--- a/src/app/api/projects/[id]/members/route.ts
+++ b/src/app/api/projects/[id]/members/route.ts
@@ -160,11 +160,15 @@ export async function POST(
     }
 
     // Continue with normal flow to add new member...
-    // Check if user already exists in users table
+    // Check if user already exists in users table.
+    // .limit(1) before .maybeSingle(): pype_voice_users.email has no unique
+    // constraint on staging, so a dual-domain account (two clerk_ids sharing
+    // this email) can legitimately have two rows here — must not 500 on that.
     const { data: existingUser, error: existingUserError } = await supabase
       .from('pype_voice_users')
       .select('clerk_id')
       .eq('email', normalizedEmail)
+      .limit(1)
       .maybeSingle()
 
     if (existingUserError) {

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -4,6 +4,8 @@ import { auth, currentUser } from '@clerk/nextjs/server'
 import crypto from 'crypto'
 import { createProjectApiKey } from '@/lib/api-key-management'
 import { createServiceRoleClient } from '@/lib/supabase-server'
+import { isPlatformAdmin } from '@/lib/isPlatformAdmin'
+import { projectMembershipMatch } from '@/lib/getProjectRoleForApi'
 
 // Create Supabase client for server-side operations (use service role for admin operations)
 const supabase = createServiceRoleClient()
@@ -158,7 +160,10 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'User email not found' }, { status: 400 })
     }
 
-    // Fetch projects linked to user email
+    // Fetch projects this login has access to. Regular users only match
+    // their own clerk_id, or an unclaimed invite created by the new-domain
+    // approval flow — not every row that merely shares this email (a
+    // different account's old-domain membership included).
     const { data: projectMappings, error } = await supabase
       .from('pype_voice_email_project_mapping')
       .select(`
@@ -173,7 +178,7 @@ export async function GET(request: NextRequest) {
         ),
         role
       `)
-      .eq('email', userEmail)
+      .or(projectMembershipMatch(userId, userEmail, isPlatformAdmin(userEmail)))
       .or('is_active.is.null,is_active.eq.true')
 
     if (error) {
@@ -181,9 +186,22 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Failed to fetch projects' }, { status: 500 })
     }
 
-    // Return only active projects with user role included
+    // Return only active projects with user role included — deduped by
+    // project id, since an admin's deliberately broad match (clerk_id OR
+    // email) can legitimately return more than one mapping row for the same
+    // project (e.g. one per old/new-domain account sharing this email).
+    const seenProjectIds = new Set<string>()
     const activeProjects = projectMappings
       .filter(mapping => mapping.project)
+      .filter(mapping => {
+        // Supabase's inferred type for this joined relation doesn't match
+        // its actual one-to-one shape at runtime (same quirk as elsewhere
+        // in this codebase) — hence the `any`.
+        const id = (mapping.project as any)?.id
+        if (seenProjectIds.has(id)) return false
+        seenProjectIds.add(id)
+        return true
+      })
       .map(mapping => ({
         ...mapping.project,
         user_role: mapping.role

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -190,16 +190,18 @@ export async function GET(request: NextRequest) {
     // project id, since an admin's deliberately broad match (clerk_id OR
     // email) can legitimately return more than one mapping row for the same
     // project (e.g. one per old/new-domain account sharing this email).
+    // Supabase infers this joined relation as an array even though it's
+    // actually one-to-one at runtime (same quirk as elsewhere in this
+    // codebase) — a single explicit cast here avoids repeating `any`.
+    type ProjectRow = { id: string; name: string; description: string | null; environment: string; is_active: boolean; owner_clerk_id: string; created_at: string }
+    const mappingsTyped = projectMappings as unknown as { project: ProjectRow | null; role: string }[]
+
     const seenProjectIds = new Set<string>()
-    const activeProjects = projectMappings
-      .filter(mapping => mapping.project)
-      .filter(mapping => {
-        // Supabase's inferred type for this joined relation doesn't match
-        // its actual one-to-one shape at runtime (same quirk as elsewhere
-        // in this codebase) — hence the `any`.
-        const id = (mapping.project as any)?.id
-        if (seenProjectIds.has(id)) return false
-        seenProjectIds.add(id)
+    const activeProjects = mappingsTyped
+      .filter((mapping): mapping is { project: ProjectRow; role: string } => {
+        if (!mapping.project) return false
+        if (seenProjectIds.has(mapping.project.id)) return false
+        seenProjectIds.add(mapping.project.id)
         return true
       })
       .map(mapping => ({

--- a/src/app/api/user/create/route.ts
+++ b/src/app/api/user/create/route.ts
@@ -45,11 +45,15 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Email not found' }, { status: 400 })
     }
 
-    // Check if already exists
+    // Check if already exists.
+    // .limit(1) before .maybeSingle(): pype_voice_users.email has no unique
+    // constraint on staging, so a dual-domain account (two clerk_ids sharing
+    // this email) can legitimately have two rows here — must not 500 on that.
     const { data: existingUser } = await supabase
       .from('pype_voice_users')
       .select('id, clerk_id')
       .or(`clerk_id.eq.${userId},email.eq.${email}`)
+      .limit(1)
       .maybeSingle()
 
     if (existingUser) {

--- a/src/lib/getProjectRoleForApi.ts
+++ b/src/lib/getProjectRoleForApi.ts
@@ -8,8 +8,23 @@ import { getEffectiveVisibility } from '@/types/visibility'
 import type { MemberVisibility } from '@/types/visibility'
 import { createServiceRoleClient } from '@/lib/supabase-server'
 import { requireApiBaseUrl } from '@/lib/pypeApiFetch'
+import { isPlatformAdmin } from '@/lib/isPlatformAdmin'
 
 const supabase = createServiceRoleClient()
+
+/**
+ * Match rule for who a mapping row belongs to. Platform admins (PYPE_ADMINS)
+ * keep the original, unrestricted "clerk_id OR email" match — same access as
+ * they've always had. Everyone else only matches by their own clerk_id, or by
+ * email when the row is a genuinely unclaimed invite (clerk_id is null) that
+ * was created within the new-domain approval flow (granted_via='new_domain').
+ * This is what stops an old-domain account's access from silently carrying
+ * over to a different login that happens to share the same email.
+ */
+export function projectMembershipMatch(userId: string, userEmail: string | undefined, admin: boolean): string {
+  if (admin) return `clerk_id.eq.${userId},email.ilike.${userEmail}`
+  return `clerk_id.eq.${userId},and(clerk_id.is.null,email.ilike.${userEmail},granted_via.eq.new_domain)`
+}
 
 export async function getProjectRoleForApi(projectId: string): Promise<{ role: string; visibility: MemberVisibility; downloadDisabled: boolean } | null> {
   const { userId } = await auth()
@@ -17,12 +32,19 @@ export async function getProjectRoleForApi(projectId: string): Promise<{ role: s
   if (!userId || !projectId) return null
 
   const userEmail = user?.emailAddresses?.[0]?.emailAddress
+  // .limit(1) before .maybeSingle(): an admin's match is deliberately broad
+  // (clerk_id OR email), so one admin can legitimately have more than one
+  // mapping row for the same project across different clerk_ids (account
+  // history, migrations). .maybeSingle() errors — not just returns null —
+  // on more than one match, which would otherwise turn "yes, a member" into
+  // a false 403 the moment that history exists.
   const { data: mapping, error } = await supabase
     .from('pype_voice_email_project_mapping')
     .select('role, permissions, is_active')
     .eq('project_id', projectId)
-    .or(`clerk_id.eq.${userId},email.ilike.${userEmail}`)
+    .or(projectMembershipMatch(userId, userEmail, isPlatformAdmin(userEmail)))
     .or('is_active.is.null,is_active.eq.true')
+    .limit(1)
     .maybeSingle()
 
   if (error || !mapping) return null

--- a/src/lib/isPlatformAdmin.ts
+++ b/src/lib/isPlatformAdmin.ts
@@ -1,0 +1,9 @@
+// New-domain signup-approval gate: an email in PYPE_ADMINS bypasses the
+// approval gate entirely (auto-active on signup, sole authority to
+// approve/decline others) and keeps the old, unrestricted email-based org
+// access match — same experience they had before this gate existed.
+export function isPlatformAdmin(email: string | null | undefined): boolean {
+  if (!email) return false
+  const admins = process.env.PYPE_ADMINS?.split(',').map(e => e.trim().toLowerCase()).filter(Boolean) || []
+  return admins.includes(email.toLowerCase())
+}


### PR DESCRIPTION
Fixes false 403 errors and duplicate project entries caused by mapping rows matched purely by email instead of account ID — a different account sharing the same email (e.g. old-domain) was sometimes mistaken for the current login, crashing requests or duplicating list entries. Isolated fix across 4 files; no other behavior on develop is changed.