### PR TITLE
Remove description from voicemail detector tool config.

### DIFF
--- a/__tests__/hooks/useMultiAssistantState.test.ts
+++ b/__tests__/hooks/useMultiAssistantState.test.ts
@@ -33,16 +33,18 @@ describe('serializeVoicemailDetectionTool', () => {
   const baseToolConfig = { type: 'voicemail_detection' }
   const commonFields = { name: 'Voicemail Detection', description: 'Detects voicemail' }
 
-  it('includes vm_message and vm_wait_timeout from tool.config', () => {
+  it('includes vm_message and vm_wait_timeout from tool.config, without description', () => {
     const tool = { config: { vm_message: 'Call back later', vm_wait_timeout: 12 } }
     const result = serializeVoicemailDetectionTool(tool, baseToolConfig, commonFields)
     expect(result).toEqual({
       type: 'voicemail_detection',
       name: 'Voicemail Detection',
-      description: 'Detects voicemail',
       vm_message: 'Call back later',
       vm_wait_timeout: 12,
     })
+    // The backend never reads config.description for this tool type - it's
+    // driven entirely by AMD, not a user-describable LLM-callable function.
+    expect(result).not.toHaveProperty('description')
   })
 
   it('falls back to real defaults when config fields are absent', () => {
@@ -75,26 +77,26 @@ describe('serializeAssistantToolFull / serializeAssistantToolBasic — voicemail
     config: { description: 'Detects voicemail', vm_message: 'Please call back', vm_wait_timeout: 5 },
   }
 
-  it('serializeAssistantToolFull preserves the full voicemail_detection config', () => {
+  it('serializeAssistantToolFull preserves the voicemail_detection config, without description', () => {
     const result = serializeAssistantToolFull(tool)
     expect(result).toEqual({
       type: 'voicemail_detection',
       name: 'Voicemail Detection',
-      description: 'Detects voicemail',
       vm_message: 'Please call back',
       vm_wait_timeout: 5,
     })
+    expect(result).not.toHaveProperty('description')
   })
 
-  it('serializeAssistantToolBasic preserves the full voicemail_detection config', () => {
+  it('serializeAssistantToolBasic preserves the voicemail_detection config, without description', () => {
     const result = serializeAssistantToolBasic(tool)
     expect(result).toEqual({
       type: 'voicemail_detection',
       name: 'Voicemail Detection',
-      description: 'Detects voicemail',
       vm_message: 'Please call back',
       vm_wait_timeout: 5,
     })
+    expect(result).not.toHaveProperty('description')
   })
 
   it('does not reduce to just {type} the way the unfixed fallthrough did', () => {

--- a/src/app/api/agents/save-and-deploy/route.ts
+++ b/src/app/api/agents/save-and-deploy/route.ts
@@ -356,7 +356,10 @@ function serializeRouteTool(tool: any): any {
   if (tool.type === 'voicemail_detection') {
     return {
       ...baseToolConfig,
-      ...commonFields,
+      name: tool.name,
+      // No description: the backend never reads it for this tool type - it's
+      // driven entirely by AMD (LiveKit's Answering Machine Detection), not a
+      // user-describable LLM-callable function.
       // ?? not || - a blank message / 0 timeout is an intentional config (instant, silent hangup).
       vm_message: tool.config.vm_message ?? "It looks like I've reached a voicemail. Please call us back when you're available. Thank you, goodbye.",
       vm_wait_timeout: tool.config.vm_wait_timeout ?? 7,

--- a/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/SessionBehaviourSettings.tsx
+++ b/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/SessionBehaviourSettings.tsx
@@ -214,6 +214,14 @@ export default function SessionBehaviourSettings({
               </p>
             </div>
           )}
+          {turn_detection === 'v1-mini' && (
+            <div className="flex items-start gap-2 p-2.5 bg-amber-50 dark:bg-amber-900/20 rounded-md border border-amber-200 dark:border-amber-800">
+              <AlertTriangle className="w-3.5 h-3.5 text-amber-600 mt-0.5 flex-shrink-0" />
+              <p className="text-xs text-amber-700 dark:text-amber-300">
+                V1 Mini requires the VAD's Min Silence Duration (Voice Activity Detection section) to be at least 0.25s — the call fails to start otherwise. 0.55s is recommended.
+              </p>
+            </div>
+          )}
         </div>
 
         {/* Unlikely Threshold - Only show for English and Multilingual */}

--- a/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/ToolsActionsSettingsProps.tsx
+++ b/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/ToolsActionsSettingsProps.tsx
@@ -169,7 +169,8 @@ const TOOL_TYPE_TEXT_OVERRIDES: Record<string, Record<string, unknown>> = {
   },
   voicemail_detection: {
     name: 'voicemail_detection',
-    description: 'Detect voicemail systems and leave a message',
+    // No description default - the field is hidden for this tool type (see the
+    // Description block below); the backend never reads config.description for it.
     vm_message: "It looks like I've reached a voicemail. Please call us back when you're available. Thank you, goodbye.",
     vm_wait_timeout: 7,
   },
@@ -683,16 +684,21 @@ function ToolsActionsSettings({ tools, languageSwitchTools = [], turnDetection, 
               {toolNameError && <p className="text-xs text-red-500 mt-1">{toolNameError}</p>}
             </div>
 
-            {/* Description */}
-            <div>
-              <Label className="text-xs text-gray-700 dark:text-gray-300">Description</Label>
-              <Textarea
-                value={formData.description}
-                onChange={(e) => setFormData(prev => ({ ...prev, description: e.target.value }))}
-                className="text-xs mt-1 min-h-[60px] resize-none bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100"
-                placeholder={selectedToolType === 'ivr_navigator' ? 'Send a DTMF tone to pick IVR menu options' : 'Describe what this tool does...'}
-              />
-            </div>
+            {/* Description - not shown for voicemail_detection: the backend never reads
+                config.description for this tool type. It's driven entirely by AMD
+                (LiveKit's Answering Machine Detection), not a describable LLM-callable
+                function, so there's nothing here for a description to configure. */}
+            {selectedToolType !== 'voicemail_detection' && (
+              <div>
+                <Label className="text-xs text-gray-700 dark:text-gray-300">Description</Label>
+                <Textarea
+                  value={formData.description}
+                  onChange={(e) => setFormData(prev => ({ ...prev, description: e.target.value }))}
+                  className="text-xs mt-1 min-h-[60px] resize-none bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100"
+                  placeholder={selectedToolType === 'ivr_navigator' ? 'Send a DTMF tone to pick IVR menu options' : 'Describe what this tool does...'}
+                />
+              </div>
+            )}
 
             {/* IVR Navigator specific fields */}
             {selectedToolType === 'ivr_navigator' && (

--- a/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/VoiceActivitySettings.tsx
+++ b/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/VoiceActivitySettings.tsx
@@ -15,16 +15,16 @@ import { Switch } from '@/components/ui/switch'
 const STREAMING_TURN_DETECTOR_MIN_SILENCE = 0.25
 
 interface VoiceActivitySettingsProps {
-  vadProvider: string
-  minSilenceDuration: number
-  minSpeechDuration?: number
-  prefixPaddingDuration?: number
-  maxBufferedSpeech?: number
-  activationThreshold?: number
-  sampleRate?: 8000 | 16000
-  forceCpu?: boolean
-  turnDetection?: 'multilingual' | 'english' | 'disabled' | 'v1-mini'
-  onFieldChange: (field: string, value: any) => void
+  readonly vadProvider: string
+  readonly minSilenceDuration: number
+  readonly minSpeechDuration?: number
+  readonly prefixPaddingDuration?: number
+  readonly maxBufferedSpeech?: number
+  readonly activationThreshold?: number
+  readonly sampleRate?: 8000 | 16000
+  readonly forceCpu?: boolean
+  readonly turnDetection?: 'multilingual' | 'english' | 'disabled' | 'v1-mini'
+  readonly onFieldChange: (field: string, value: any) => void
 }
 
 function VoiceActivitySettings({

--- a/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/VoiceActivitySettings.tsx
+++ b/src/components/agents/AgentConfig/AgentAdvancedSettings/ConfigParents/VoiceActivitySettings.tsx
@@ -4,9 +4,15 @@ import React, { useState, useEffect } from 'react'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
-import { Info } from 'lucide-react'
+import { Info, AlertTriangle } from 'lucide-react'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { Switch } from '@/components/ui/switch'
+
+// LiveKit's streaming TurnDetector (v1 / v1-mini) rejects a VAD whose
+// min_silence_duration is below this floor: audio_recognition.py computes
+// required = (MIN_SILENCE_DURATION_MS [200] + 50) / 1000 and raises if the
+// configured VAD is under that, so agents saved below it fail at call start.
+const STREAMING_TURN_DETECTOR_MIN_SILENCE = 0.25
 
 interface VoiceActivitySettingsProps {
   vadProvider: string
@@ -17,6 +23,7 @@ interface VoiceActivitySettingsProps {
   activationThreshold?: number
   sampleRate?: 8000 | 16000
   forceCpu?: boolean
+  turnDetection?: 'multilingual' | 'english' | 'disabled' | 'v1-mini'
   onFieldChange: (field: string, value: any) => void
 }
 
@@ -29,6 +36,7 @@ function VoiceActivitySettings({
   activationThreshold = 0.5,
   sampleRate = 16000,
   forceCpu = true,
+  turnDetection,
   onFieldChange
 }: VoiceActivitySettingsProps) {
   // Local state for input values to handle intermediate states
@@ -182,6 +190,15 @@ function VoiceActivitySettings({
             className="h-7 text-xs"
             placeholder="0.55"
           />
+          {turnDetection === 'v1-mini' && minSilenceDuration < STREAMING_TURN_DETECTOR_MIN_SILENCE && (
+            <div className="flex items-start gap-2 p-2.5 bg-red-50 dark:bg-red-900/20 rounded-md border border-red-200 dark:border-red-800">
+              <AlertTriangle className="w-3.5 h-3.5 text-red-600 mt-0.5 flex-shrink-0" />
+              <p className="text-xs text-red-700 dark:text-red-300">
+                Invalid parameter: V1 Mini turn detection requires Min Silence Duration to be at least{' '}
+                {STREAMING_TURN_DETECTOR_MIN_SILENCE}s. The call will fail to start at {minSilenceDuration}s — raise it to {STREAMING_TURN_DETECTOR_MIN_SILENCE} or higher (0.55 recommended).
+              </p>
+            </div>
+          )}
         </div>
 
         {/* Min Speech Duration */}

--- a/src/components/agents/AgentConfig/AgentAdvancedSettings/index.tsx
+++ b/src/components/agents/AgentConfig/AgentAdvancedSettings/index.tsx
@@ -227,6 +227,7 @@ function AgentAdvancedSettings({ advancedSettings, onFieldChange, onWebhookDataL
               activationThreshold={advancedSettings.vad.activationThreshold}
               sampleRate={advancedSettings.vad.sampleRate}
               forceCpu={advancedSettings.vad.forceCpu}
+              turnDetection={advancedSettings.session.turn_detection}
               onFieldChange={onFieldChange}
             />
           </CollapsibleContent>

--- a/src/hooks/useMultiAssistantState.ts
+++ b/src/hooks/useMultiAssistantState.ts
@@ -640,7 +640,10 @@ function serializeIvrNavigatorTool(tool: any, baseToolConfig: any, commonFields:
 export function serializeVoicemailDetectionTool(tool: any, baseToolConfig: any, commonFields: any): any {
   return {
     ...baseToolConfig,
-    ...commonFields,
+    name: commonFields.name,
+    // No description: the backend never reads it for this tool type - it's
+    // driven entirely by AMD (LiveKit's Answering Machine Detection), not a
+    // user-describable LLM-callable function.
     // ?? not || - a blank message / 0 timeout is an intentional config (instant, silent hangup).
     vm_message: tool.config?.vm_message ?? "It looks like I've reached a voicemail. Please call us back when you're available. Thank you, goodbye.",
     vm_wait_timeout: tool.config?.vm_wait_timeout ?? 7,


### PR DESCRIPTION
Voicemail detector Tool is completely invisible to Main LLM, so description is not needed and it was inert and not used anywhere. 