### PR TITLE
Fix/enable 408 and window guard (#578)

### DIFF
--- a/__tests__/utils/backoffWindowWarning.test.ts
+++ b/__tests__/utils/backoffWindowWarning.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { backoffWindowWarning } from '@/components/campaigns/RetryConfiguration'
+import { VALID_SIP_ERROR_CODE_VALUES } from '@/utils/campaigns/constants'
+
+// The scheduler only dials inside [startTime, endTime], so a retry due after
+// endTime waits for tomorrow. A leg being shorter than the window is NOT
+// enough: a leg of L minutes only lands the same day if the call happened
+// before endTime - L. Two live campaigns had a 480m leg in a 10:00-18:30
+// window (480 < 510, so a naive length check passes) and looked stuck.
+describe('backoffWindowWarning', () => {
+  it('catches the real case a naive leg-vs-window check misses', () => {
+    const w = backoffWindowWarning([15, 480, 300], '10:00', '18:30')
+    expect(w).toContain('8h')
+    expect(w).toContain('10:30')   // endTime 18:30 minus 8h
+    expect(w).toContain('slip to the next day')
+  })
+
+  it('reports the cutoff for a wider window too', () => {
+    // 09:00-21:00: an 8h leg still works, but only for calls before 13:00
+    expect(backoffWindowWarning([15, 480, 300], '09:00', '21:00')).toContain('13:00')
+  })
+
+  it('says "always slip" when a leg is at least the whole window', () => {
+    const w = backoffWindowWarning([600], '09:00', '18:00') // 600m leg, 9h window
+    expect(w).toContain('always slip to the next day')
+    expect(w).toContain('9h')
+  })
+
+  it('stays silent for short legs that comfortably fit', () => {
+    expect(backoffWindowWarning([15, 60, 240], '09:00', '21:00')).toBeNull()
+    expect(backoffWindowWarning([15, 15, 15], '10:00', '18:30')).toBeNull()
+  })
+
+  it('counts every offending leg and reports the worst', () => {
+    const w = backoffWindowWarning([15, 600, 700], '09:00', '18:00')
+    expect(w).toContain('2')
+    expect(w).toContain('700m')  // worst, and not a round hour
+    expect(w).toContain('delays')
+  })
+
+  it('uses singular wording for a single offending leg', () => {
+    expect(backoffWindowWarning([15, 600], '09:00', '18:00')).toContain('delay')
+  })
+
+  it('is silent for fixed-delay rules (no backoff schedule)', () => {
+    expect(backoffWindowWarning(undefined, '10:00', '18:30')).toBeNull()
+    expect(backoffWindowWarning([], '10:00', '18:30')).toBeNull()
+  })
+
+  it('is silent rather than wrong when the window is unusable', () => {
+    expect(backoffWindowWarning([480], undefined, '18:30')).toBeNull()
+    expect(backoffWindowWarning([480], 'garbage', '18:30')).toBeNull()
+    expect(backoffWindowWarning([480], '25:00', '18:30')).toBeNull()
+    expect(backoffWindowWarning([480], '10:00', '09:00')).toBeNull() // end before start
+  })
+
+  it('does not warn for the default all-day window', () => {
+    expect(backoffWindowWarning([15, 480, 300], '00:00', '23:59')).toBeNull()
+  })
+})
+
+// 408 was gated in the picker pending an RCA that has since completed. Gating
+// it was what guaranteed every campaign omitted 408 and silently inherited the
+// backend's injected default instead of the user's own rule.
+describe('SIP code allow-list', () => {
+  it('accepts 408, so a campaign can cover it explicitly', () => {
+    expect(VALID_SIP_ERROR_CODE_VALUES).toContain('408')
+  })
+
+  it('still accepts the other transient codes', () => {
+    for (const code of ['480', '486', '487', '500', '503', '504', '600', '603']) {
+      expect(VALID_SIP_ERROR_CODE_VALUES).toContain(code)
+    }
+  })
+
+  it('does not accept permanent-failure codes', () => {
+    for (const code of ['401', '403', '404']) {
+      expect(VALID_SIP_ERROR_CODE_VALUES).not.toContain(code)
+    }
+  })
+})

--- a/src/app/[projectid]/campaigns/create/page.tsx
+++ b/src/app/[projectid]/campaigns/create/page.tsx
@@ -589,6 +589,8 @@ function CreateCampaign() {
                     retryConfig: values.retryConfig,
                     agentId: values.agentId,
                     agentRuntime: values.agentRuntime,  // ← ADD
+                    callWindowStart: values.callWindowStart,
+                    callWindowEnd: values.callWindowEnd,
                   }}
                 />
 

--- a/src/components/campaigns/RetryConfiguration.tsx
+++ b/src/components/campaigns/RetryConfiguration.tsx
@@ -325,7 +325,68 @@ interface RetryConfigurationProps {
     retryConfig: RetryConfig[]
     agentId?: string
     agentRuntime?: 'livekit' | 'pipecat' | 'acefone_bridge'
+    // Calling window, "HH:MM". Used only to warn when a backoff leg is longer
+    // than the window — see backoffWindowWarning.
+    callWindowStart?: string
+    callWindowEnd?: string
   }
+}
+
+/** Minutes from midnight for a "HH:MM" string, or null if unparseable. */
+function parseHHMM(value?: string): number | null {
+  const m = /^(\d{1,2}):(\d{2})$/.exec(value?.trim() ?? '')
+  if (!m) return null
+  const [h, min] = [Number(m[1]), Number(m[2])]
+  if (h > 23 || min > 59) return null
+  return h * 60 + min
+}
+
+const fmtDuration = (m: number) => (m % 60 === 0 ? `${m / 60}h` : `${m}m`)
+const fmtClock = (minutesFromMidnight: number) =>
+  `${String(Math.floor(minutesFromMidnight / 60)).padStart(2, '0')}`
+  + `:${String(minutesFromMidnight % 60).padStart(2, '0')}`
+
+/**
+ * Warn when a backoff leg is too long to land inside the calling window.
+ *
+ * The scheduler only dials inside [startTime, endTime], so a retry due after
+ * endTime waits for tomorrow's window. Crucially it is NOT enough for a leg to
+ * be shorter than the window: a leg of L minutes only lands the same day when
+ * the call itself happened before endTime - L. Two live campaigns had a 480m
+ * leg in a 10:00-18:30 window — 480 < 510, so a naive "leg vs window length"
+ * check passes — yet only calls before 10:30 could retry that day and the rest
+ * sat on a future nextCallAt for hours, looking stuck.
+ *
+ * Fires when a leg exceeds half the window, i.e. when most of the day's calls
+ * cannot get a same-day retry. Returns null when the schedule is workable.
+ */
+export function backoffWindowWarning(
+  backoffMinutes: number[] | undefined,
+  callWindowStart?: string,
+  callWindowEnd?: string
+): string | null {
+  if (!Array.isArray(backoffMinutes) || backoffMinutes.length === 0) return null
+  const start = parseHHMM(callWindowStart)
+  const end = parseHHMM(callWindowEnd)
+  if (start === null || end === null || end <= start) return null
+
+  const windowMinutes = end - start
+  const legs = backoffMinutes.filter((m) => typeof m === 'number' && m > windowMinutes / 2)
+  if (legs.length === 0) return null
+
+  const worst = Math.max(...legs)
+  const which = legs.length === 1 ? 'A' : `${legs.length}`
+  const delay = legs.length === 1 ? 'delay' : 'delays'
+  const head = `${which} ${fmtDuration(worst)} retry ${delay} in this schedule `
+
+  // A leg at least as long as the window can never land the same day.
+  if (worst >= windowMinutes) {
+    return head + `exceeds your ${fmtDuration(windowMinutes)} calling window `
+      + `(${callWindowStart}–${callWindowEnd}), so those retries always slip to the next day.`
+  }
+  return head + `only lands the same day for calls placed before `
+    + `${fmtClock(end - worst)} — later calls slip to the next day, `
+    + `since the window closes at ${callWindowEnd}.`
 }
 
 export function RetryConfiguration({ onFieldChange, values }: RetryConfigurationProps) {
@@ -954,6 +1015,25 @@ export function RetryConfiguration({ onFieldChange, values }: RetryConfiguration
                           Total retries = {(config.backoffMinutes || []).length} (max 10).
                           Minimum 5 minutes per entry. Repeated values are allowed.
                         </p>
+                        {(() => {
+                          const warning = backoffWindowWarning(
+                            config.backoffMinutes,
+                            values.callWindowStart,
+                            values.callWindowEnd
+                          )
+                          if (!warning) return null
+                          // <output> over role="status": it carries the same
+                          // live-region semantics natively and announces the
+                          // recalculated warning as the schedule is edited.
+                          // Inline by default, hence block.
+                          return (
+                            <output
+                              className="block text-xs mt-2 rounded-md px-2 py-1.5 bg-amber-50 text-amber-800 border border-amber-200 dark:bg-amber-950/40 dark:text-amber-200 dark:border-amber-900"
+                            >
+                              {warning}
+                            </output>
+                          )
+                        })()}
                       </div>
                     )}
                   </div>

--- a/src/hooks/useVoiceAgent.ts
+++ b/src/hooks/useVoiceAgent.ts
@@ -256,7 +256,16 @@ export function useVoiceAgent({ agentName, mode, sessionEndpoint = '/api/agents/
       if (!sessionData.token && !sessionData.user_token) throw new Error('No token in session response.')
       await liveKitRoom.connect(sessionData.url, sessionData.token || sessionData.user_token!, { autoSubscribe: true })
       if (mode === 'voice') {
-        await liveKitRoom.localParticipant.setMicrophoneEnabled(true).catch(e => console.warn('Mic enable failed:', e))
+        // Swallowing this used to mean: room connects fine, transcript panel
+        // shows the agent's greeting, everything LOOKS connected — but no
+        // local audio track ever gets published, so the agent never receives
+        // a single frame of the caller's voice and just sits there silently.
+        // Surface it instead of only logging, so a denied/blocked mic is
+        // visible rather than indistinguishable from "STT isn't working."
+        await liveKitRoom.localParticipant.setMicrophoneEnabled(true).catch(e => {
+          console.warn('Mic enable failed:', e)
+          setConnectionError(`Microphone access failed (${e?.name || 'error'}): ${e?.message || e}. Check your browser's mic permission for this site.`)
+        })
       }
       // chat mode: mic stays off, no audio elements created
     } catch (error) {

--- a/src/utils/campaigns/constants.ts
+++ b/src/utils/campaigns/constants.ts
@@ -74,12 +74,18 @@ export interface SipCode {
   code: string
   label: string
   description: string
-  // Frontend-only picker gate — does NOT affect what the Yup schema or the
-  // schedule API route accept (VALID_SIP_ERROR_CODE_VALUES is intentionally
-  // left unfiltered). Temporary: while we RCA the retry-count/backoff-order
-  // issues seen with the full 9-code set, the picker only lets a user select
-  // the pre-existing 480/486; the rest render disabled as "Coming soon" so
-  // the groups/UI don't need rebuilding once codes are re-enabled.
+  // Picker gate AND validation gate: a disabled code renders as "Coming soon"
+  // and is stripped from VALID_SIP_ERROR_CODE_VALUES, so the Yup schema and the
+  // schedule API route reject it too — it cannot be sent even by direct API
+  // call. All nine codes are currently enabled; the flag stays so a code can be
+  // pulled quickly if one turns out to be a bad retry candidate.
+  //
+  // History worth keeping: 408 was disabled here pending RCA of
+  // "retry-count/backoff-order" issues. That RCA found two backend bugs — the
+  // scheduler resolved retryConfig by first find() match, so an auto-injected
+  // 408 default shadowed the user's own rule, and the analytics lambda ignored
+  // backoffMinutes entirely. Both are fixed. Disabling 408 had in fact
+  // GUARANTEED the shadowing, since no campaign could ever include 408.
   enabled: boolean
 }
 
@@ -147,8 +153,7 @@ export const VALID_SIP_ERROR_CODES: SipCode[] = SIP_CODE_GROUPS.flatMap(g => g.c
 // Only enabled codes — this is what the Yup schema and schedule/route.ts's
 // backend validator actually accept. Filtered (not the full list above) so a
 // disabled code is rejected even via a direct API call, not just blocked in
-// the picker UI. Temporary, pending RCA on the retry-count/backoff-order
-// issue seen with the full 9-code set (see sip-codes.data.json comments).
+// the picker UI. See SipCode.enabled for why 408 was gated and why it isn't.
 export const VALID_SIP_ERROR_CODE_VALUES = VALID_SIP_ERROR_CODES.filter(c => c.enabled).map(c => c.code)
 
 // Retry Configuration

--- a/src/utils/campaigns/sip-codes.data.json
+++ b/src/utils/campaigns/sip-codes.data.json
@@ -43,7 +43,7 @@
         "code": "408",
         "label": "Request Timeout",
         "description": "Server/network couldn't reach the destination in time. Usually a transient network issue.",
-        "enabled": false
+        "enabled": true
       },
       {
         "code": "504",


### PR DESCRIPTION
* fix: dark-theme Controls/MiniMap on the workflow canvas, add explicit Fit view button

Both rendered with xyflow's hardcoded light-mode defaults (white buttons/background) against the dark canvas — near-invisible and mismatched. xyflow ships its own dark theme, gated behind a literal 'dark' class on the ReactFlow root (not just an ancestor .dark), so wire that from next-themes' resolvedTheme instead of hand-rolling CSS overrides.

Also added a labeled 'Fit view' button next to Auto-arrange — Controls' built-in fit-view is icon-only and easy to miss/not realize exists.



* fix: scope dark-mode fix to Controls buttons only, drop MiniMap

The blanket .react-flow.dark class changed far more than the controls — background dots, edge stroke, node colors, selection color — which is what actually looked wrong, not just visible. Override only the specific --xy-controls-button-* CSS variables xyflow uses for the zoom/fit-view/ lock buttons, leaving the canvas's own existing colors untouched.

Also removed the minimap per feedback — not needed for typical workflow sizes and added visual clutter.



* fix: hide xyflow's default 'React Flow' attribution badge



* fix: cap textarea auto-grow height, scroll internally past that

The shared Textarea component uses field-sizing-content (grows to fit typed text) with nothing capping how tall that gets — a long prompt/ script (e.g. the initial 'what should this agent do?' box, or a node's prompt in the Inspector) pushed the whole page taller instead of scrolling in place. Capped at max-h-80 with overflow-y-auto; a caller can still override max-h-* per field if it genuinely needs to grow past that.



* fix: default Sarvam Saaras STT language, teach AI Builder to avoid stall-prone graphs

Default STT config (name:sarvam, model:saaras:v3) omitted language, which fell through to sttConfig's own default of 'en' — not a valid BCP-47 code for saaras:v3, so the backend's Sarvam plugin (workflow/providers.py -> livekit/plugins/sarvam) raised and silently fell back to Deepgram on every fresh agent. language:'unknown' is Sarvam's actual auto-detect sentinel.

Also added a HARD RULE to the AI Builder's system prompt: a conversation/extract_variable/subagent node whose only outgoing edges are all 'condition' kind has no way forward once the caller's reply doesn't cleanly match one of them — same class of bug as the existing logic_split fallback rule, just for condition edges. Found by tracing a live agent's actual saved graph: greeting had 5 condition edges and no fallback, so any reply that didn't match one of the five phrasings left the call stuck on the greeting node.



* fix: default LLM provider name to 'azure', not 'azure_openai'

Backend's build_llm() dispatch table only recognized 'azure' — an unrecognized name silently falls through to plain OpenAI instead of erroring, and since gpt-4.1-mini is also a real OpenAI model id, that misroute produced no visible error. Confirmed live via LLM metrics (model_provider logged as api.openai.com instead of Azure). Backend now also accepts 'azure_openai' as an alias (companion fix on pype-voice-agent), but the default here should still name what the backend's canonical key actually is.



* feat: default workflow STT to saaras:v4

The Sarvam plugin's own current default model (installed version already supports it, same allowed-language set as v3 including the 'unknown' auto-detect sentinel) — matches the model version just exposed in the classic agent config's SelectSTTDialog (saaras-v4, #570).



* feat: harden AI Builder system prompt — distillation, provider checklist, follow-up questions

Three gaps found while debugging live workflows this session:
1. Pasted configs were being copied near-verbatim into globalPrompt/node prompts instead of distilled — redundant tags, meta-commentary, and restated rules all made it into the agent's actual runtime prompt.
2. No explicit checklist for llm/stt/tts provider+parameter correctness, which is exactly how the azure_openai naming mismatch, the sarvam language validation gap, and the elevenlabs voice_settings casing bug all slipped through — the model had no rule telling it these shapes are provider-specific and must be verified, not guessed.
3. HARD RULE #0 already (correctly) tells the model not to stall a build over vague domain requests, but gave no carve-out for fields that genuinely need a real value (API endpoints, phone numbers, trunk ids) where a wrong guess breaks the workflow silently instead of just being generic — added a narrow rule for when to ask instead of fabricate.

* fix: surface mic-enable failures in the Talk to Assistant test panel

setMicrophoneEnabled(true) failures were swallowed into a console.warn only. The room connection still succeeds, so the panel shows "Connected" with a live transcript for the agent's greeting and looks completely healthy — but with no local audio track ever published, the agent never receives a frame of the caller's voice. Traced this via 3 consecutive live test calls on chat-agent-server-main-v2: identical signature every time (greeting plays, 15s silence, session goes "away", nothing else), with the backend STT/LLM/TTS pipeline fully healthy in the logs. Now surfaces the failure via connectionError so it isn't indistinguishable from "STT isn't working."

* fix: enable 408 retries and warn on backoff that outlives the call window

408 was the only disabled SIP code in the picker, gated pending RCA of "retry-count/backoff-order" issues. That RCA is done: the scheduler resolved retryConfig by first find() match so an auto-injected 408 default shadowed the user's own rule, and the analytics lambda ignored backoffMinutes entirely. Both are fixed backend-side.

Gating 408 had in fact guaranteed the shadowing — enabled is also the validation gate (VALID_SIP_ERROR_CODE_VALUES), so no campaign could ever cover 408, even via direct API call, and every one of them inherited the injected default. Three live campaigns needed hand-patching.

Also adds backoffWindowWarning: a leg being shorter than the calling window is not enough, since a leg of L minutes only lands the same day when the call happened before endTime - L. Two campaigns had a 480m leg in a 10:00-18:30 window (480 < 510, so a naive length check passes) and only calls before 10:30 could retry that day; the rest sat on a future nextCallAt for hours and looked stuck. The picker now names that cutoff.



* fix: use <output> for the backoff window warning (sonar a11y)

SonarQube: "Use <output> instead of the 'status' role to ensure accessibility across all devices." <output> carries the same live-region semantics natively, so the recalculated warning is still announced as the schedule is edited. Needs an explicit block, since <output> is inline by default.



---------